### PR TITLE
feat: Frontend Quality Engine — design tokens, component registry, Brand Guardian

### DIFF
--- a/packages/cli/src/commands/design.ts
+++ b/packages/cli/src/commands/design.ts
@@ -1,0 +1,114 @@
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+import {
+  detectDesignTokens,
+  generateDefaultTokens,
+  detectComponentRegistry,
+  runBrandGuardian,
+  generateDesignSystemConfig,
+} from '@qlucent/fishi-core';
+
+export async function designCommand(
+  action: string,
+  options: { output?: string }
+): Promise<void> {
+  const targetDir = process.cwd();
+
+  if (action === 'detect') {
+    console.log('');
+    console.log(chalk.cyan.bold('  FISHI Design System — Detect'));
+    console.log('');
+
+    const tokens = detectDesignTokens(targetDir);
+    const registry = detectComponentRegistry(targetDir);
+
+    console.log(chalk.white.bold('  Design Tokens'));
+    console.log(chalk.gray(`    Colors:        ${Object.keys(tokens.colors).length} detected`));
+    console.log(chalk.gray(`    Typography:    ${tokens.typography.fontFamilies.length} font families, ${Object.keys(tokens.typography.scale).length} scale values`));
+    console.log(chalk.gray(`    Spacing:       ${Object.keys(tokens.spacing).length} values`));
+    console.log(chalk.gray(`    Border radius: ${Object.keys(tokens.borderRadius).length} values`));
+    console.log(chalk.gray(`    Dark mode:     ${tokens.darkMode ? chalk.green('yes') : chalk.yellow('no')}`));
+    console.log('');
+    console.log(chalk.white.bold('  Component Registry'));
+    console.log(chalk.gray(`    Library:       ${registry.library || 'none detected'}`));
+    console.log(chalk.gray(`    Framework:     ${registry.framework || 'none detected'}`));
+    console.log(chalk.gray(`    Components:    ${registry.components.length} found`));
+    if (registry.components.length > 0) {
+      const byType: Record<string, number> = {};
+      for (const c of registry.components) byType[c.type] = (byType[c.type] || 0) + 1;
+      for (const [type, count] of Object.entries(byType)) {
+        console.log(chalk.gray(`      ${type}: ${count}`));
+      }
+    }
+    console.log('');
+
+    // Save config
+    if (options.output || fs.existsSync(path.join(targetDir, '.fishi'))) {
+      const outputPath = options.output || path.join(targetDir, '.fishi', 'design-system.json');
+      const dir = path.dirname(outputPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(outputPath, generateDesignSystemConfig(tokens, registry), 'utf-8');
+      console.log(chalk.green(`  Saved to ${path.relative(targetDir, outputPath)}`));
+    }
+
+  } else if (action === 'init') {
+    console.log('');
+    console.log(chalk.cyan.bold('  FISHI Design System — Initialize'));
+    console.log('');
+
+    // Detect existing or generate defaults
+    let tokens = detectDesignTokens(targetDir);
+    const hasExisting = Object.keys(tokens.colors).length > 0;
+
+    if (!hasExisting) {
+      tokens = generateDefaultTokens();
+      console.log(chalk.yellow('  No design tokens found — using FISHI defaults.'));
+    } else {
+      console.log(chalk.green(`  Detected ${Object.keys(tokens.colors).length} colors from your project.`));
+    }
+
+    const registry = detectComponentRegistry(targetDir);
+    const outputPath = path.join(targetDir, '.fishi', 'design-system.json');
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(outputPath, generateDesignSystemConfig(tokens, registry), 'utf-8');
+
+    console.log(chalk.green(`  Design system saved to .fishi/design-system.json`));
+    console.log(chalk.gray('  Your agents will use these tokens for consistent styling.'));
+    console.log('');
+
+  } else if (action === 'validate') {
+    console.log('');
+    console.log(chalk.cyan.bold('  FISHI Brand Guardian — Validation'));
+    console.log('');
+
+    const tokens = detectDesignTokens(targetDir);
+    const report = runBrandGuardian(targetDir, tokens);
+
+    if (report.issues.length === 0) {
+      console.log(chalk.green('  No issues found! Your frontend follows the design system.'));
+    } else {
+      for (const issue of report.issues) {
+        const icon = issue.severity === 'error' ? chalk.red('ERROR') : issue.severity === 'warning' ? chalk.yellow('WARN') : chalk.blue('INFO');
+        console.log(`  ${icon} ${chalk.gray(issue.file)}:${issue.line}`);
+        console.log(`        ${issue.message}`);
+        if (issue.fix) console.log(`        ${chalk.gray('Fix: ' + issue.fix)}`);
+      }
+    }
+
+    console.log('');
+    console.log(chalk.white.bold('  Summary'));
+    console.log(chalk.gray(`    Files scanned: ${report.stats.filesScanned}`));
+    console.log(chalk.red(`    Errors:        ${report.stats.errors}`));
+    console.log(chalk.yellow(`    Warnings:      ${report.stats.warnings}`));
+    console.log(chalk.blue(`    Info:          ${report.stats.infos}`));
+    console.log(`    Status:        ${report.passed ? chalk.green('PASSED') : chalk.red('FAILED')}`);
+    console.log('');
+
+    if (!report.passed) process.exit(1);
+
+  } else {
+    console.log(chalk.yellow(`  Unknown action: ${action}. Use: detect, init, validate`));
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { dashboardCommand } from './commands/dashboard.js';
 import { sandboxCommand } from './commands/sandbox.js';
 import { quickstartCommand } from './commands/quickstart.js';
 import { previewCommand } from './commands/preview.js';
+import { designCommand } from './commands/design.js';
 
 const program = new Command();
 
@@ -98,5 +99,12 @@ program
   .option('--dev-cmd <cmd>', 'Custom dev server command')
   .option('--port <port>', 'Dev server port')
   .action(previewCommand);
+
+program
+  .command('design')
+  .description('Design system — detect tokens, init design system, validate with Brand Guardian')
+  .argument('<action>', 'Action: detect | init | validate')
+  .option('-o, --output <path>', 'Output path for design config')
+  .action(designCommand);
 
 program.parse();

--- a/packages/core/src/__tests__/design-system.test.ts
+++ b/packages/core/src/__tests__/design-system.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  detectDesignTokens,
+  generateDefaultTokens,
+  detectComponentRegistry,
+  runBrandGuardian,
+  generateDesignSystemConfig,
+} from '../generators/design-system';
+
+describe('Design System', () => {
+  let tempDir: string;
+
+  function createTempDir(): string {
+    tempDir = mkdtempSync(join(tmpdir(), 'fishi-design-'));
+    return tempDir;
+  }
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('detectDesignTokens', () => {
+    it('returns empty tokens for project without config', () => {
+      const dir = createTempDir();
+      const tokens = detectDesignTokens(dir);
+      expect(Object.keys(tokens.colors).length).toBe(0);
+    });
+
+    it('detects colors from CSS custom properties', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'globals.css'), ':root {\n  --color-primary: #0066cc;\n  --color-bg: #ffffff;\n}\n');
+      const tokens = detectDesignTokens(dir);
+      expect(tokens.colors['color-primary']).toBe('#0066cc');
+    });
+
+    it('detects dark mode from CSS', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'globals.css'), '.dark { --bg: #000; }\n');
+      const tokens = detectDesignTokens(dir);
+      expect(tokens.darkMode).toBe(true);
+    });
+
+    it('detects colors from tailwind config', () => {
+      const dir = createTempDir();
+      writeFileSync(join(dir, 'tailwind.config.js'), `module.exports = {\n  theme: {\n    colors: {\n      primary: '#3b82f6',\n      secondary: '#10b981',\n    }\n  }\n};\n`);
+      const tokens = detectDesignTokens(dir);
+      expect(tokens.colors['primary']).toBe('#3b82f6');
+    });
+  });
+
+  describe('generateDefaultTokens', () => {
+    it('returns complete token set', () => {
+      const tokens = generateDefaultTokens();
+      expect(Object.keys(tokens.colors).length).toBeGreaterThan(10);
+      expect(tokens.typography.fontFamilies.length).toBeGreaterThan(0);
+      expect(Object.keys(tokens.spacing).length).toBeGreaterThan(5);
+      expect(Object.keys(tokens.borderRadius).length).toBeGreaterThan(3);
+      expect(tokens.darkMode).toBe(true);
+    });
+
+    it('includes brand, gray, and semantic colors', () => {
+      const tokens = generateDefaultTokens();
+      expect(tokens.colors['brand-500']).toBeDefined();
+      expect(tokens.colors['gray-900']).toBeDefined();
+      expect(tokens.colors['error']).toBeDefined();
+    });
+  });
+
+  describe('detectComponentRegistry', () => {
+    it('returns empty registry for project without components', () => {
+      const dir = createTempDir();
+      const registry = detectComponentRegistry(dir);
+      expect(registry.components).toHaveLength(0);
+      expect(registry.library).toBeNull();
+    });
+
+    it('detects shadcn from components.json', () => {
+      const dir = createTempDir();
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { react: '^18' } }));
+      writeFileSync(join(dir, 'components.json'), '{}');
+      const registry = detectComponentRegistry(dir);
+      expect(registry.library).toBe('shadcn');
+      expect(registry.framework).toBe('react');
+    });
+
+    it('detects MUI from package.json', () => {
+      const dir = createTempDir();
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ dependencies: { '@mui/material': '^5', react: '^18' } }));
+      const registry = detectComponentRegistry(dir);
+      expect(registry.library).toBe('mui');
+    });
+
+    it('scans component files from src/components', () => {
+      const dir = createTempDir();
+      writeFileSync(join(dir, 'package.json'), '{}');
+      mkdirSync(join(dir, 'src', 'components'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'components', 'Button.tsx'), 'export function Button() {}');
+      writeFileSync(join(dir, 'src', 'components', 'Header.tsx'), 'export function Header() {}');
+      writeFileSync(join(dir, 'src', 'components', 'LoginForm.tsx'), 'export function LoginForm() {}');
+      const registry = detectComponentRegistry(dir);
+      expect(registry.components.length).toBe(3);
+      expect(registry.components.find(c => c.name === 'Button')?.type).toBe('ui');
+      expect(registry.components.find(c => c.name === 'Header')?.type).toBe('layout');
+      expect(registry.components.find(c => c.name === 'LoginForm')?.type).toBe('form');
+    });
+
+    it('classifies components by type', () => {
+      const dir = createTempDir();
+      writeFileSync(join(dir, 'package.json'), '{}');
+      mkdirSync(join(dir, 'src', 'components'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'components', 'DataTable.tsx'), '');
+      writeFileSync(join(dir, 'src', 'components', 'NavBar.tsx'), '');
+      const registry = detectComponentRegistry(dir);
+      expect(registry.components.find(c => c.name === 'DataTable')?.type).toBe('data');
+      expect(registry.components.find(c => c.name === 'NavBar')?.type).toBe('navigation');
+    });
+  });
+
+  describe('runBrandGuardian', () => {
+    it('passes for clean project', () => {
+      const dir = createTempDir();
+      const tokens = generateDefaultTokens();
+      const report = runBrandGuardian(dir, tokens);
+      expect(report.passed).toBe(true);
+      expect(report.issues).toHaveLength(0);
+    });
+
+    it('detects hardcoded hex colors', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'App.tsx'), '<div className="bg-[#ff0000]">test</div>\n');
+      const report = runBrandGuardian(dir, generateDefaultTokens());
+      const colorIssues = report.issues.filter(i => i.rule === 'no-hardcoded-colors');
+      expect(colorIssues.length).toBeGreaterThan(0);
+    });
+
+    it('detects images without alt text', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'Page.tsx'), '<img src="photo.jpg" />\n');
+      const report = runBrandGuardian(dir, generateDefaultTokens());
+      const altIssues = report.issues.filter(i => i.rule === 'img-alt-text');
+      expect(altIssues.length).toBe(1);
+      expect(altIssues[0].severity).toBe('error');
+    });
+
+    it('detects click handlers without keyboard support', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'Comp.tsx'), '<div onClick={handleClick}>click me</div>\n');
+      const report = runBrandGuardian(dir, generateDefaultTokens());
+      const kbIssues = report.issues.filter(i => i.rule === 'keyboard-accessible');
+      expect(kbIssues.length).toBe(1);
+    });
+
+    it('detects inline px values', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'Box.tsx'), '<div style={{ padding: "16px", margin: "24px" }}>box</div>\n');
+      const report = runBrandGuardian(dir, generateDefaultTokens());
+      const pxIssues = report.issues.filter(i => i.rule === 'no-inline-px');
+      expect(pxIssues.length).toBeGreaterThan(0);
+    });
+
+    it('returns proper stats', () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(join(dir, 'src', 'Page.tsx'), '<img src="a.jpg" />\n<div style={{ padding: "10px" }}>test</div>');
+      const report = runBrandGuardian(dir, generateDefaultTokens());
+      expect(report.stats.filesScanned).toBe(1);
+      expect(report.stats.errors).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('generateDesignSystemConfig', () => {
+    it('generates valid JSON config', () => {
+      const tokens = generateDefaultTokens();
+      const registry = { components: [{ name: 'Button', path: 'src/components/Button.tsx', type: 'ui' as const }], library: 'shadcn' as const, framework: 'react' as const };
+      const config = generateDesignSystemConfig(tokens, registry);
+      const parsed = JSON.parse(config);
+      expect(parsed.version).toBe('1.0');
+      expect(parsed.tokens.colors['brand-500']).toBeDefined();
+      expect(parsed.components.library).toBe('shadcn');
+      expect(parsed.components.count).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/generators/design-system.ts
+++ b/packages/core/src/generators/design-system.ts
@@ -1,0 +1,414 @@
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+export interface DesignTokens {
+  colors: Record<string, string>;
+  typography: {
+    fontFamilies: string[];
+    scale: Record<string, string>;
+  };
+  spacing: Record<string, string>;
+  borderRadius: Record<string, string>;
+  shadows: Record<string, string>;
+  darkMode: boolean;
+}
+
+export interface ComponentEntry {
+  name: string;
+  path: string;
+  type: 'ui' | 'layout' | 'form' | 'data' | 'navigation' | 'other';
+}
+
+export interface ComponentRegistry {
+  components: ComponentEntry[];
+  library: string | null; // shadcn, radix, mui, antd, etc.
+  framework: string | null;
+}
+
+export interface BrandGuardianIssue {
+  file: string;
+  line: number;
+  severity: 'error' | 'warning' | 'info';
+  rule: string;
+  message: string;
+  fix?: string;
+}
+
+export interface BrandGuardianReport {
+  issues: BrandGuardianIssue[];
+  passed: boolean;
+  stats: {
+    errors: number;
+    warnings: number;
+    infos: number;
+    filesScanned: number;
+  };
+}
+
+/**
+ * Detect design tokens from a project's config files.
+ * Checks: tailwind.config, CSS custom properties, theme files.
+ */
+export function detectDesignTokens(projectDir: string): DesignTokens {
+  const tokens: DesignTokens = {
+    colors: {},
+    typography: { fontFamilies: [], scale: {} },
+    spacing: {},
+    borderRadius: {},
+    shadows: {},
+    darkMode: false,
+  };
+
+  // Check tailwind.config.js/ts/mjs
+  const tailwindFiles = ['tailwind.config.js', 'tailwind.config.ts', 'tailwind.config.mjs', 'tailwind.config.cjs'];
+  for (const file of tailwindFiles) {
+    const p = join(projectDir, file);
+    if (existsSync(p)) {
+      const content = readFileSync(p, 'utf-8');
+      // Extract colors
+      const colorMatches = content.matchAll(/['"]?([\w-]+)['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})['"]?/g);
+      for (const m of colorMatches) {
+        tokens.colors[m[1]] = m[2];
+      }
+      // Check dark mode
+      if (content.includes('darkMode')) tokens.darkMode = true;
+      break;
+    }
+  }
+
+  // Check CSS files for custom properties
+  const cssFiles = findFiles(projectDir, ['src', 'styles', 'app'], ['.css']);
+  for (const file of cssFiles.slice(0, 10)) {
+    try {
+      const content = readFileSync(file, 'utf-8');
+      const varMatches = content.matchAll(/--(\w[\w-]*)\s*:\s*([^;]+)/g);
+      for (const m of varMatches) {
+        const name = m[1];
+        const value = m[2].trim();
+        if (name.includes('color') || name.includes('bg') || value.startsWith('#') || value.startsWith('rgb') || value.startsWith('hsl')) {
+          tokens.colors[name] = value;
+        } else if (name.includes('font')) {
+          if (name.includes('size')) tokens.typography.scale[name] = value;
+          else if (name.includes('family')) tokens.typography.fontFamilies.push(value);
+        } else if (name.includes('spacing') || name.includes('gap') || name.includes('padding') || name.includes('margin')) {
+          tokens.spacing[name] = value;
+        } else if (name.includes('radius')) {
+          tokens.borderRadius[name] = value;
+        } else if (name.includes('shadow')) {
+          tokens.shadows[name] = value;
+        }
+      }
+      // Check for dark mode
+      if (content.includes('prefers-color-scheme: dark') || content.includes('.dark')) {
+        tokens.darkMode = true;
+      }
+    } catch {}
+  }
+
+  // Check for theme file
+  const themeFiles = ['theme.ts', 'theme.js', 'theme.json', 'src/theme.ts', 'src/theme.js', 'src/styles/theme.ts'];
+  for (const file of themeFiles) {
+    if (existsSync(join(projectDir, file))) {
+      try {
+        const content = readFileSync(join(projectDir, file), 'utf-8');
+        const colorMatches = content.matchAll(/['"]?([\w-]+)['"]?\s*:\s*['"]?(#[0-9a-fA-F]{3,8})['"]?/g);
+        for (const m of colorMatches) {
+          tokens.colors[m[1]] = m[2];
+        }
+      } catch {}
+      break;
+    }
+  }
+
+  return tokens;
+}
+
+/**
+ * Generate default design tokens for a new project.
+ */
+export function generateDefaultTokens(): DesignTokens {
+  return {
+    colors: {
+      'brand-50': '#f0f7ff',
+      'brand-100': '#e0efff',
+      'brand-200': '#b8d9ff',
+      'brand-500': '#0066cc',
+      'brand-600': '#0052a3',
+      'brand-700': '#003d7a',
+      'brand-900': '#001f3f',
+      'gray-50': '#f9fafb',
+      'gray-100': '#f3f4f6',
+      'gray-200': '#e5e7eb',
+      'gray-500': '#6b7280',
+      'gray-700': '#374151',
+      'gray-900': '#111827',
+      'success': '#22c55e',
+      'warning': '#f59e0b',
+      'error': '#ef4444',
+    },
+    typography: {
+      fontFamilies: ['-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'],
+      scale: {
+        'xs': '0.75rem',
+        'sm': '0.875rem',
+        'base': '1rem',
+        'lg': '1.125rem',
+        'xl': '1.25rem',
+        '2xl': '1.5rem',
+        '3xl': '1.875rem',
+        '4xl': '2.25rem',
+      },
+    },
+    spacing: {
+      'xs': '0.25rem',
+      'sm': '0.5rem',
+      'md': '1rem',
+      'lg': '1.5rem',
+      'xl': '2rem',
+      '2xl': '3rem',
+      '3xl': '4rem',
+    },
+    borderRadius: {
+      'sm': '0.25rem',
+      'md': '0.375rem',
+      'lg': '0.5rem',
+      'xl': '0.75rem',
+      'full': '9999px',
+    },
+    shadows: {
+      'sm': '0 1px 2px rgba(0,0,0,0.05)',
+      'md': '0 4px 6px rgba(0,0,0,0.1)',
+      'lg': '0 10px 15px rgba(0,0,0,0.1)',
+    },
+    darkMode: true,
+  };
+}
+
+/**
+ * Detect component library and registry from a project.
+ */
+export function detectComponentRegistry(projectDir: string): ComponentRegistry {
+  const registry: ComponentRegistry = {
+    components: [],
+    library: null,
+    framework: null,
+  };
+
+  // Detect component library from package.json
+  const pkgPath = join(projectDir, 'package.json');
+  if (existsSync(pkgPath)) {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    if (deps['@shadcn/ui'] || existsSync(join(projectDir, 'components.json'))) registry.library = 'shadcn';
+    else if (deps['@radix-ui/react-dialog'] || deps['@radix-ui/themes']) registry.library = 'radix';
+    else if (deps['@mui/material']) registry.library = 'mui';
+    else if (deps['antd']) registry.library = 'antd';
+    else if (deps['@chakra-ui/react']) registry.library = 'chakra';
+    else if (deps['@headlessui/react']) registry.library = 'headlessui';
+
+    if (deps['react'] || deps['react-dom']) registry.framework = 'react';
+    else if (deps['vue']) registry.framework = 'vue';
+    else if (deps['svelte']) registry.framework = 'svelte';
+    else if (deps['@angular/core']) registry.framework = 'angular';
+  }
+
+  // Scan for components
+  const componentDirs = ['src/components', 'components', 'src/ui', 'app/components', 'src/components/ui'];
+  for (const dir of componentDirs) {
+    const fullDir = join(projectDir, dir);
+    if (existsSync(fullDir)) {
+      try {
+        scanComponents(fullDir, dir, registry.components);
+      } catch {}
+    }
+  }
+
+  return registry;
+}
+
+function scanComponents(dir: string, relBase: string, components: ComponentEntry[]): void {
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        scanComponents(join(dir, entry.name), `${relBase}/${entry.name}`, components);
+      } else if (entry.name.match(/\.(tsx|jsx|vue|svelte)$/)) {
+        const name = entry.name.replace(/\.(tsx|jsx|vue|svelte)$/, '');
+        if (name === 'index') continue; // Skip barrel files
+        const type = classifyComponent(name);
+        components.push({ name, path: `${relBase}/${entry.name}`, type });
+      }
+    }
+  } catch {}
+}
+
+function classifyComponent(name: string): ComponentEntry['type'] {
+  const lower = name.toLowerCase();
+  if (/button|badge|avatar|icon|tag|chip|tooltip/i.test(lower)) return 'ui';
+  if (/layout|header|footer|sidebar|menu/i.test(lower)) return 'layout';
+  if (/input|form|select|checkbox|radio|textarea|switch|slider/i.test(lower)) return 'form';
+  if (/table|list|card|grid|chart|graph|stat/i.test(lower)) return 'data';
+  if (/link|breadcrumb|tab|pagination|stepper|nav|navbar/i.test(lower)) return 'navigation';
+  return 'other';
+}
+
+/**
+ * Run Brand Guardian validation on project files.
+ * Checks for hardcoded colors, inconsistent spacing, missing a11y, etc.
+ */
+export function runBrandGuardian(projectDir: string, tokens: DesignTokens): BrandGuardianReport {
+  const issues: BrandGuardianIssue[] = [];
+  let filesScanned = 0;
+
+  // Scan frontend files
+  const files = findFiles(projectDir, ['src', 'app', 'pages', 'components'], ['.tsx', '.jsx', '.vue', '.svelte', '.css']);
+
+  for (const file of files.slice(0, 100)) { // Cap at 100 files
+    try {
+      const content = readFileSync(file, 'utf-8');
+      const lines = content.split('\n');
+      const relPath = file.replace(projectDir, '').replace(/\\/g, '/').replace(/^\//, '');
+      filesScanned++;
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const lineNum = i + 1;
+
+        // Rule: Hardcoded hex colors (not in comments or strings defining tokens)
+        if (file.match(/\.(tsx|jsx|vue|svelte)$/)) {
+          const hexMatches = line.matchAll(/#[0-9a-fA-F]{3,8}\b/g);
+          for (const m of hexMatches) {
+            // Skip if in a comment
+            if (line.trimStart().startsWith('//') || line.trimStart().startsWith('*')) continue;
+            // Skip if in CSS variable definition
+            if (line.includes('--')) continue;
+            issues.push({
+              file: relPath,
+              line: lineNum,
+              severity: 'warning',
+              rule: 'no-hardcoded-colors',
+              message: `Hardcoded color ${m[0]} — use design tokens instead`,
+              fix: 'Replace with a CSS variable or Tailwind class from your design system',
+            });
+          }
+        }
+
+        // Rule: Inline styles with px values (not responsive)
+        if (line.includes('style=') && line.match(/\d+px/)) {
+          issues.push({
+            file: relPath,
+            line: lineNum,
+            severity: 'warning',
+            rule: 'no-inline-px',
+            message: 'Inline px values — use spacing tokens or Tailwind classes',
+            fix: 'Replace px values with spacing scale (xs, sm, md, lg, xl)',
+          });
+        }
+
+        // Rule: Images without alt text
+        if (line.match(/<img\b/) && !line.includes('alt=') && !line.includes('alt =')) {
+          issues.push({
+            file: relPath,
+            line: lineNum,
+            severity: 'error',
+            rule: 'img-alt-text',
+            message: 'Image missing alt attribute — accessibility violation',
+            fix: 'Add alt="descriptive text" or alt="" for decorative images',
+          });
+        }
+
+        // Rule: Click handler without keyboard support
+        if (line.includes('onClick') && !line.includes('onKeyDown') && !line.includes('onKeyUp') && !line.includes('onKeyPress')) {
+          if (line.includes('<div') || line.includes('<span')) {
+            issues.push({
+              file: relPath,
+              line: lineNum,
+              severity: 'warning',
+              rule: 'keyboard-accessible',
+              message: 'Click handler on non-interactive element without keyboard support',
+              fix: 'Add onKeyDown handler and role="button" tabIndex={0}, or use <button>',
+            });
+          }
+        }
+
+        // Rule: Hardcoded font-size
+        if (line.match(/font-size:\s*\d+px/) && !line.includes('--')) {
+          issues.push({
+            file: relPath,
+            line: lineNum,
+            severity: 'info',
+            rule: 'use-typography-scale',
+            message: 'Hardcoded font-size — use typography scale tokens',
+            fix: 'Replace with typography scale class (text-xs, text-sm, text-base, etc.)',
+          });
+        }
+
+        // Rule: Missing lang attribute on html
+        if (line.match(/<html\b/) && !line.includes('lang=')) {
+          issues.push({
+            file: relPath,
+            line: lineNum,
+            severity: 'error',
+            rule: 'html-lang',
+            message: 'HTML element missing lang attribute — accessibility violation',
+            fix: 'Add lang="en" (or appropriate language code) to <html>',
+          });
+        }
+      }
+    } catch {}
+  }
+
+  const errors = issues.filter(i => i.severity === 'error').length;
+  const warnings = issues.filter(i => i.severity === 'warning').length;
+  const infos = issues.filter(i => i.severity === 'info').length;
+
+  return {
+    issues,
+    passed: errors === 0,
+    stats: { errors, warnings, infos, filesScanned },
+  };
+}
+
+/**
+ * Generate a design system config file for the project.
+ */
+export function generateDesignSystemConfig(tokens: DesignTokens, registry: ComponentRegistry): string {
+  return JSON.stringify({
+    version: '1.0',
+    tokens,
+    components: {
+      library: registry.library,
+      framework: registry.framework,
+      count: registry.components.length,
+      entries: registry.components,
+    },
+  }, null, 2) + '\n';
+}
+
+// Helper: Find files in directories with specific extensions
+function findFiles(base: string, dirs: string[], extensions: string[]): string[] {
+  const files: string[] = [];
+  for (const dir of dirs) {
+    const fullDir = join(base, dir);
+    if (existsSync(fullDir)) {
+      walkDir(fullDir, extensions, files);
+    }
+  }
+  return files;
+}
+
+function walkDir(dir: string, extensions: string[], result: string[]): void {
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'dist' || entry.name === '.git') continue;
+        walkDir(full, extensions, result);
+      } else if (extensions.some(ext => entry.name.endsWith(ext))) {
+        result.push(full);
+      }
+    }
+  } catch {}
+}

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -11,3 +11,5 @@ export { detectDocker, readSandboxConfig, readSandboxPolicy, buildSandboxEnv, ru
 export type { SandboxMode, SandboxConfig, SandboxPolicy, SandboxRunResult } from './sandbox';
 export { detectDevServer, startDevServer, getVibeModeConfig } from './preview-server';
 export type { DevServerConfig } from './preview-server';
+export { detectDesignTokens, generateDefaultTokens, detectComponentRegistry, runBrandGuardian, generateDesignSystemConfig } from './design-system';
+export type { DesignTokens, ComponentEntry, ComponentRegistry, BrandGuardianIssue, BrandGuardianReport } from './design-system';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,8 @@ export { detectDocker, readSandboxConfig, readSandboxPolicy, buildSandboxEnv, ru
 export type { SandboxMode, SandboxConfig, SandboxPolicy, SandboxRunResult } from './generators/index';
 export { detectDevServer, startDevServer, getVibeModeConfig } from './generators/index';
 export type { DevServerConfig } from './generators/index';
+export { detectDesignTokens, generateDefaultTokens, detectComponentRegistry, runBrandGuardian, generateDesignSystemConfig } from './generators/index';
+export type { DesignTokens, ComponentEntry, ComponentRegistry, BrandGuardianIssue, BrandGuardianReport } from './generators/index';
 export { getSandboxPolicyTemplate } from './templates/configs/sandbox-policy';
 export { getDockerfileTemplate } from './templates/docker/Dockerfile';
 export { getDashboardHtml } from './templates/dashboard/index-html';


### PR DESCRIPTION
## Summary

Fixes the #1 complaint about AI coding tools: ugly, generic UIs. FISHI now auto-detects design systems, maintains a component registry, and validates frontend code with Brand Guardian.

### New Commands

| Command | What |
|---------|------|
| `fishi design detect` | Scan project for design tokens + components |
| `fishi design init` | Create/detect design system config |
| `fishi design validate` | Run Brand Guardian validation |

### Design Token Detection
- **Tailwind config** — extracts colors, dark mode setting
- **CSS custom properties** — `--color-*`, `--spacing-*`, `--font-*`, `--radius-*`, `--shadow-*`
- **Theme files** — `theme.ts`, `theme.js`, `theme.json`
- **Default tokens** — 16 colors, 8 typography scales, 7 spacing values, 5 radii, 3 shadows, dark mode

### Component Registry
- Auto-scans `src/components/`, `components/`, `src/ui/`
- Detects library: shadcn, Radix, MUI, Ant Design, Chakra, Headless UI
- Classifies components: ui, layout, form, data, navigation
- Detects framework: React, Vue, Svelte, Angular

### Brand Guardian Validation (6 rules)

| Rule | Severity | What it catches |
|------|----------|----------------|
| `no-hardcoded-colors` | warning | `#ff0000` in JSX — use design tokens |
| `no-inline-px` | warning | `style={{ padding: "16px" }}` — use spacing scale |
| `img-alt-text` | error | `<img>` without `alt` attribute |
| `keyboard-accessible` | warning | `onClick` on `<div>` without `onKeyDown` |
| `use-typography-scale` | info | `font-size: 14px` — use scale tokens |
| `html-lang` | error | `<html>` without `lang` attribute |

### Output
Saves design system config to `.fishi/design-system.json` — tokens + component inventory used by agents as context.

### Stats
- 518 tests (500 + 18 new), all passing
- Zero new npm dependencies
- Both packages build

## Test plan
- [x] All 518 tests pass
- [x] Token detection from Tailwind, CSS vars, theme files
- [x] Component scanning + classification
- [x] Library detection (shadcn, MUI, Radix, etc.)
- [x] Brand Guardian: hardcoded colors, missing alt, keyboard a11y, inline px
- [x] Both packages build
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)