### PR TITLE
feat: Domain-Specific Agents + Deep Research Agent

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,8 +3,8 @@ import ora from 'ora';
 import inquirer from 'inquirer';
 import path from 'path';
 import fs from 'fs';
-import type { CostMode, InitOptions, ProjectType } from '@qlucent/fishi-core';
-import { detectConflicts, createBackup, detectDocker } from '@qlucent/fishi-core';
+import type { CostMode, InitOptions, ProjectType, ProjectDomain } from '@qlucent/fishi-core';
+import { detectConflicts, createBackup, detectDocker, getAvailableDomains, getDomainConfigYaml } from '@qlucent/fishi-core';
 import type { FileResolutionMap, ConflictResolution } from '@qlucent/fishi-core';
 import { detectProjectType } from '../analyzers/detector.js';
 import { runBrownfieldAnalysis, type BrownfieldAnalysis } from '../analyzers/brownfield.js';
@@ -180,6 +180,21 @@ export async function initCommand(
     }
   }
 
+  // ── Domain Selection ────────────────────────────────────────────
+  let selectedDomain: ProjectDomain = 'general';
+
+  if (options.interactive !== false) {
+    const domains = getAvailableDomains();
+    const { domain } = await inquirer.prompt([{
+      type: 'list',
+      name: 'domain',
+      message: 'What type of application are you building?',
+      choices: domains,
+      default: 'general',
+    }]);
+    selectedDomain = domain;
+  }
+
   // ── Conflict Detection ──────────────────────────────────────────
   const conflictResult = detectConflicts(targetDir);
   let resolutions: FileResolutionMap | undefined;
@@ -281,6 +296,7 @@ export async function initCommand(
       resolutions,
       docsReadmeExists: conflictResult?.docsReadmeExists,
       rootClaudeMdExists: conflictResult?.rootClaudeMdExists,
+      domain: selectedDomain,
     });
 
     // Write brownfield report if analysis was performed
@@ -299,6 +315,14 @@ export async function initCommand(
     const fishiYamlPath = path.join(targetDir, '.fishi', 'fishi.yaml');
     if (fs.existsSync(fishiYamlPath)) {
       fs.appendFileSync(fishiYamlPath, sandboxYaml, 'utf-8');
+    }
+
+    // Write domain config
+    if (selectedDomain !== 'general') {
+      const fishiYamlPath2 = path.join(targetDir, '.fishi', 'fishi.yaml');
+      if (fs.existsSync(fishiYamlPath2)) {
+        fs.appendFileSync(fishiYamlPath2, getDomainConfigYaml(selectedDomain), 'utf-8');
+      }
     }
 
     // Write sandbox policy

--- a/packages/cli/src/generators/scaffold.ts
+++ b/packages/cli/src/generators/scaffold.ts
@@ -1,4 +1,4 @@
-import type { InitOptions, ProjectType, ScaffoldResult, BrownfieldAnalysisData, FileResolutionMap } from '@qlucent/fishi-core';
+import type { InitOptions, ProjectType, ScaffoldResult, BrownfieldAnalysisData, FileResolutionMap, ProjectDomain } from '@qlucent/fishi-core';
 import { generateScaffold } from '@qlucent/fishi-core';
 
 interface ScaffoldOptions extends InitOptions {
@@ -8,6 +8,7 @@ interface ScaffoldOptions extends InitOptions {
   resolutions?: FileResolutionMap;
   docsReadmeExists?: boolean;
   rootClaudeMdExists?: boolean;
+  domain?: ProjectDomain;
 }
 
 export async function scaffold(

--- a/packages/core/src/__tests__/domain-agents.test.ts
+++ b/packages/core/src/__tests__/domain-agents.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { getSaasArchitectTemplate } from '../templates/agents/domains/saas-architect';
+import { getMarketplaceArchitectTemplate } from '../templates/agents/domains/marketplace-architect';
+import { getMobileArchitectTemplate } from '../templates/agents/domains/mobile-architect';
+import { getAimlArchitectTemplate } from '../templates/agents/domains/aiml-architect';
+import { getDeepResearchAgentTemplate } from '../templates/agents/domains/deep-research';
+import { getDeepResearchSkill } from '../templates/skills/deep-research';
+
+describe('Domain Agent Templates', () => {
+  it('saas architect has YAML frontmatter with domain', () => {
+    const t = getSaasArchitectTemplate();
+    expect(t).toContain('name: saas-architect');
+    expect(t).toContain('domain: saas');
+    expect(t).toContain('Stripe');
+    expect(t).toContain('multi-tenancy');
+  });
+
+  it('marketplace architect has YAML frontmatter with domain', () => {
+    const t = getMarketplaceArchitectTemplate();
+    expect(t).toContain('name: marketplace-architect');
+    expect(t).toContain('domain: marketplace');
+    expect(t).toContain('escrow');
+    expect(t).toContain('Stripe Connect');
+  });
+
+  it('mobile architect has YAML frontmatter with domain', () => {
+    const t = getMobileArchitectTemplate();
+    expect(t).toContain('name: mobile-architect');
+    expect(t).toContain('domain: mobile');
+    expect(t).toContain('PWA');
+    expect(t).toContain('offline');
+  });
+
+  it('aiml architect has YAML frontmatter with domain', () => {
+    const t = getAimlArchitectTemplate();
+    expect(t).toContain('name: aiml-architect');
+    expect(t).toContain('domain: aiml');
+    expect(t).toContain('RAG');
+    expect(t).toContain('embeddings');
+  });
+
+  it('deep research agent has proper structure', () => {
+    const t = getDeepResearchAgentTemplate();
+    expect(t).toContain('name: deep-research-agent');
+    expect(t).toContain('Domain Research');
+    expect(t).toContain('Competitive Analysis');
+    expect(t).toContain('Tech Stack Research');
+    expect(t).toContain('Best Practices');
+    expect(t).toContain('Security Research');
+    expect(t).toContain('.fishi/research/');
+  });
+
+  it('deep research skill has workflow steps', () => {
+    const s = getDeepResearchSkill();
+    expect(s).toContain('name: deep-research');
+    expect(s).toContain('Define Research Scope');
+    expect(s).toContain('Gather Information');
+    expect(s).toContain('Synthesize Findings');
+    expect(s).toContain('Produce Report');
+  });
+});

--- a/packages/core/src/__tests__/domain-manager.test.ts
+++ b/packages/core/src/__tests__/domain-manager.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  getAvailableDomains,
+  readDomainConfig,
+  getDomainConfigYaml,
+  DOMAIN_INFO,
+} from '../generators/domain-manager';
+
+describe('Domain Manager', () => {
+  let tempDir: string;
+
+  function createTempDir(): string {
+    tempDir = mkdtempSync(join(tmpdir(), 'fishi-domain-'));
+    mkdirSync(join(tempDir, '.fishi'), { recursive: true });
+    return tempDir;
+  }
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('getAvailableDomains', () => {
+    it('returns 5 domains', () => {
+      const domains = getAvailableDomains();
+      expect(domains).toHaveLength(5);
+    });
+
+    it('includes saas, marketplace, mobile, aiml, general', () => {
+      const domains = getAvailableDomains();
+      const values = domains.map(d => d.value);
+      expect(values).toContain('saas');
+      expect(values).toContain('marketplace');
+      expect(values).toContain('mobile');
+      expect(values).toContain('aiml');
+      expect(values).toContain('general');
+    });
+
+    it('each domain has a descriptive name', () => {
+      const domains = getAvailableDomains();
+      for (const d of domains) {
+        expect(d.name.length).toBeGreaterThan(10);
+      }
+    });
+  });
+
+  describe('DOMAIN_INFO', () => {
+    it('saas has agent', () => {
+      expect(DOMAIN_INFO.saas.agent).toBe('saas-architect');
+    });
+
+    it('marketplace has agent', () => {
+      expect(DOMAIN_INFO.marketplace.agent).toBe('marketplace-architect');
+    });
+
+    it('general has no agent', () => {
+      expect(DOMAIN_INFO.general.agent).toBeNull();
+    });
+  });
+
+  describe('readDomainConfig', () => {
+    it('returns general when no fishi.yaml', () => {
+      const dir = createTempDir();
+      const config = readDomainConfig(dir);
+      expect(config.domain).toBe('general');
+      expect(config.domainAgent).toBeNull();
+    });
+
+    it('reads domain from fishi.yaml', () => {
+      const dir = createTempDir();
+      writeFileSync(join(dir, '.fishi', 'fishi.yaml'), 'domain:\n  type: saas\n  research_enabled: true\n');
+      const config = readDomainConfig(dir);
+      expect(config.domain).toBe('saas');
+      expect(config.domainAgent).toBe('saas-architect');
+      expect(config.researchEnabled).toBe(true);
+    });
+  });
+
+  describe('getDomainConfigYaml', () => {
+    it('generates saas config', () => {
+      const yaml = getDomainConfigYaml('saas');
+      expect(yaml).toContain('type: saas');
+      expect(yaml).toContain('saas-architect');
+      expect(yaml).toContain('research_enabled: true');
+    });
+
+    it('generates general config with no agent', () => {
+      const yaml = getDomainConfigYaml('general');
+      expect(yaml).toContain('type: general');
+      expect(yaml).toContain('specialist_agent: none');
+    });
+  });
+});

--- a/packages/core/src/__tests__/scaffold.test.ts
+++ b/packages/core/src/__tests__/scaffold.test.ts
@@ -37,8 +37,8 @@ describe('generateScaffold', () => {
     expect(result).toHaveProperty('hookCount');
     expect(result).toHaveProperty('filesCreated');
 
-    expect(result.agentCount).toBe(18);
-    expect(result.skillCount).toBe(12);
+    expect(result.agentCount).toBe(19);
+    expect(result.skillCount).toBe(13);
     expect(result.commandCount).toBe(8);
     expect(result.hookCount).toBe(16);
     expect(result.filesCreated).toBeGreaterThan(0);
@@ -354,7 +354,7 @@ describe('generateScaffold', () => {
         ...defaultOptions,
         projectType: 'brownfield',
       });
-      expect(result.agentCount).toBe(18);
+      expect(result.agentCount).toBe(19);
     });
 
     it('handles hybrid project type', async () => {
@@ -363,7 +363,7 @@ describe('generateScaffold', () => {
         ...defaultOptions,
         projectType: 'hybrid',
       });
-      expect(result.agentCount).toBe(18);
+      expect(result.agentCount).toBe(19);
     });
 
     it('handles economy cost mode', async () => {
@@ -496,8 +496,8 @@ describe('generateScaffold — brownfield with resolutions', () => {
     const dir = createTempDir();
     const result = await generateScaffold(dir, defaultOptions);
 
-    expect(result.agentCount).toBe(18);
-    expect(result.skillCount).toBe(12);
+    expect(result.agentCount).toBe(19);
+    expect(result.skillCount).toBe(13);
     expect(result.commandCount).toBe(8);
     expect(result.filesCreated).toBeGreaterThan(0);
     expect(existsSync(join(dir, '.claude', 'CLAUDE.md'))).toBe(true);

--- a/packages/core/src/generators/domain-manager.ts
+++ b/packages/core/src/generators/domain-manager.ts
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+export type ProjectDomain = 'saas' | 'marketplace' | 'mobile' | 'aiml' | 'general';
+
+export interface DomainConfig {
+  domain: ProjectDomain;
+  domainAgent: string | null;
+  researchEnabled: boolean;
+}
+
+export const DOMAIN_INFO: Record<ProjectDomain, { label: string; description: string; agent: string | null }> = {
+  saas: {
+    label: 'SaaS',
+    description: 'Subscription billing, multi-tenancy, user management (Stripe, Auth0)',
+    agent: 'saas-architect',
+  },
+  marketplace: {
+    label: 'Marketplace',
+    description: 'Two-sided platform, escrow, disputes, vendor management (Stripe Connect)',
+    agent: 'marketplace-architect',
+  },
+  mobile: {
+    label: 'Mobile / PWA',
+    description: 'Progressive web app, offline sync, push notifications, responsive design',
+    agent: 'mobile-architect',
+  },
+  aiml: {
+    label: 'AI / ML',
+    description: 'RAG pipelines, embeddings, fine-tuning, model serving, LLM integration',
+    agent: 'aiml-architect',
+  },
+  general: {
+    label: 'General',
+    description: 'No domain specialization — use base agents only',
+    agent: null,
+  },
+};
+
+/**
+ * Get the list of available domains for selection.
+ */
+export function getAvailableDomains(): { value: ProjectDomain; name: string }[] {
+  return Object.entries(DOMAIN_INFO).map(([key, info]) => ({
+    value: key as ProjectDomain,
+    name: `${info.label} — ${info.description}`,
+  }));
+}
+
+/**
+ * Read domain config from fishi.yaml.
+ */
+export function readDomainConfig(projectDir: string): DomainConfig {
+  const yamlPath = join(projectDir, '.fishi', 'fishi.yaml');
+  if (!existsSync(yamlPath)) {
+    return { domain: 'general', domainAgent: null, researchEnabled: false };
+  }
+  const content = readFileSync(yamlPath, 'utf-8');
+  const domainMatch = content.match(/^\s*type:\s*(\w+)/m);
+  const researchMatch = content.match(/^\s*research_enabled:\s*(true|false)/m);
+  const domain = (domainMatch?.[1] as ProjectDomain) || 'general';
+  return {
+    domain,
+    domainAgent: DOMAIN_INFO[domain]?.agent || null,
+    researchEnabled: researchMatch?.[1] === 'true',
+  };
+}
+
+/**
+ * Get the domain config YAML to append to fishi.yaml.
+ */
+export function getDomainConfigYaml(domain: ProjectDomain): string {
+  const info = DOMAIN_INFO[domain];
+  return `
+domain:
+  type: ${domain}
+  label: "${info.label}"
+  specialist_agent: ${info.agent || 'none'}
+  research_enabled: true
+`;
+}

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -13,3 +13,5 @@ export { detectDevServer, startDevServer, getVibeModeConfig } from './preview-se
 export type { DevServerConfig } from './preview-server';
 export { detectDesignTokens, generateDefaultTokens, detectComponentRegistry, runBrandGuardian, generateDesignSystemConfig } from './design-system';
 export type { DesignTokens, ComponentEntry, ComponentRegistry, BrandGuardianIssue, BrandGuardianReport } from './design-system';
+export { getAvailableDomains, readDomainConfig, getDomainConfigYaml, DOMAIN_INFO } from './domain-manager';
+export type { ProjectDomain, DomainConfig } from './domain-manager';

--- a/packages/core/src/generators/scaffold.ts
+++ b/packages/core/src/generators/scaffold.ts
@@ -44,6 +44,15 @@ import { getPrdSkill } from '../templates/skills/prd.js';
 import { getBrownfieldDiscoverySkill } from '../templates/skills/brownfield-discovery.js';
 import { getAdaptiveTaskGraphSkill } from '../templates/skills/adaptive-taskgraph.js';
 import { getDocumentationSkill } from '../templates/skills/documentation.js';
+import { getDeepResearchSkill } from '../templates/skills/deep-research.js';
+
+// Domain agent templates
+import { getSaasArchitectTemplate } from '../templates/agents/domains/saas-architect.js';
+import { getMarketplaceArchitectTemplate } from '../templates/agents/domains/marketplace-architect.js';
+import { getMobileArchitectTemplate } from '../templates/agents/domains/mobile-architect.js';
+import { getAimlArchitectTemplate } from '../templates/agents/domains/aiml-architect.js';
+import { getDeepResearchAgentTemplate } from '../templates/agents/domains/deep-research.js';
+import type { ProjectDomain } from './domain-manager.js';
 
 // Hook templates
 import { getSessionStartHook } from '../templates/hooks/session-start.js';
@@ -98,6 +107,7 @@ export interface ScaffoldOptions extends InitOptions {
   resolutions?: FileResolutionMap;
   docsReadmeExists?: boolean;
   rootClaudeMdExists?: boolean;
+  domain?: ProjectDomain;
 }
 
 export interface ScaffoldResult {
@@ -157,6 +167,7 @@ export async function generateScaffold(
     '.claude/skills/brownfield-discovery',
     '.claude/skills/adaptive-taskgraph',
     '.claude/skills/documentation',
+    '.claude/skills/deep-research',
     '.claude/commands',
     'docs',
     '.fishi/plans/prd',
@@ -174,6 +185,7 @@ export async function generateScaffold(
     '.fishi/todos/agents',
     '.fishi/learnings/by-domain',
     '.fishi/learnings/by-agent',
+    '.fishi/research',
     '.trees',
   ];
   for (const dir of dirs) {
@@ -199,7 +211,26 @@ export async function generateScaffold(
   await write('.claude/agents/docs-agent.md', docsAgentTemplate(ctx), 'agents');
   await write('.claude/agents/writing-agent.md', writingAgentTemplate(ctx), 'agents');
   await write('.claude/agents/marketing-agent.md', marketingAgentTemplate(ctx), 'agents');
-  const agentCount = 18;
+  let agentCount = 18;
+
+  // ── Deep Research Agent (always included) ────────────────────────
+  await write('.claude/agents/deep-research-agent.md', getDeepResearchAgentTemplate(), 'agents');
+  agentCount++;
+
+  // ── Domain-Specific Agent (if domain selected) ──────────────────
+  if (options.domain && options.domain !== 'general') {
+    const domainTemplates: Record<string, () => string> = {
+      saas: getSaasArchitectTemplate,
+      marketplace: getMarketplaceArchitectTemplate,
+      mobile: getMobileArchitectTemplate,
+      aiml: getAimlArchitectTemplate,
+    };
+    const template = domainTemplates[options.domain];
+    if (template) {
+      await write(`.claude/agents/${options.domain}-architect.md`, template(), 'agents');
+      agentCount++;
+    }
+  }
 
   // ── Agent Factory Templates ───────────────────────────────────────
   await write('.fishi/agent-factory/agent-template.md', getAgentFactoryTemplate());
@@ -218,7 +249,10 @@ export async function generateScaffold(
   await write('.claude/skills/brownfield-discovery/SKILL.md', getBrownfieldDiscoverySkill(), 'skills');
   await write('.claude/skills/adaptive-taskgraph/SKILL.md', getAdaptiveTaskGraphSkill(), 'skills');
   await write('.claude/skills/documentation/SKILL.md', getDocumentationSkill(), 'skills');
-  const skillCount = 12;
+
+  // ── Deep Research Skill ──────────────────────────────────────────
+  await write('.claude/skills/deep-research/SKILL.md', getDeepResearchSkill(), 'skills');
+  const skillCount = 13;
 
   // ── Hooks (7 .mjs scripts) ───────────────────────────────────────
   await write('.fishi/scripts/session-start.mjs', getSessionStartHook());

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,15 @@ export {
   marketingAgentTemplate,
 } from './templates/agents/index';
 
+// Domain agent templates
+export {
+  getSaasArchitectTemplate,
+  getMarketplaceArchitectTemplate,
+  getMobileArchitectTemplate,
+  getAimlArchitectTemplate,
+  getDeepResearchAgentTemplate,
+} from './templates/agents/domains/index';
+
 // Skill templates
 export {
   getBrainstormingSkill,
@@ -67,6 +76,7 @@ export {
   getBrownfieldDiscoverySkill,
   getAdaptiveTaskGraphSkill,
   getDocumentationSkill,
+  getDeepResearchSkill,
 } from './templates/skills/index';
 
 // Hook templates
@@ -144,6 +154,8 @@ export { detectDevServer, startDevServer, getVibeModeConfig } from './generators
 export type { DevServerConfig } from './generators/index';
 export { detectDesignTokens, generateDefaultTokens, detectComponentRegistry, runBrandGuardian, generateDesignSystemConfig } from './generators/index';
 export type { DesignTokens, ComponentEntry, ComponentRegistry, BrandGuardianIssue, BrandGuardianReport } from './generators/index';
+export { getAvailableDomains, readDomainConfig, getDomainConfigYaml, DOMAIN_INFO } from './generators/index';
+export type { ProjectDomain, DomainConfig } from './generators/index';
 export { getSandboxPolicyTemplate } from './templates/configs/sandbox-policy';
 export { getDockerfileTemplate } from './templates/docker/Dockerfile';
 export { getDashboardHtml } from './templates/dashboard/index-html';

--- a/packages/core/src/templates/agents/domains/aiml-architect.ts
+++ b/packages/core/src/templates/agents/domains/aiml-architect.ts
@@ -1,0 +1,56 @@
+export function getAimlArchitectTemplate(): string {
+  return `---
+name: aiml-architect
+description: >
+  Specialized architect for AI/ML applications.
+  Deep knowledge of RAG pipelines, embeddings, fine-tuning, model serving.
+model: opus
+role: worker
+reports_to: planning-lead
+domain: aiml
+---
+
+# AI/ML Architect — Domain Specialist
+
+You are a specialized architect for AI and machine learning applications.
+
+## Domain Knowledge
+
+### RAG (Retrieval-Augmented Generation)
+- Document ingestion: PDF, HTML, Markdown, code files
+- Chunking strategies: fixed-size, semantic, recursive character splitting
+- Embedding models: OpenAI text-embedding-3, Cohere embed, local (sentence-transformers)
+- Vector databases: Pinecone, Weaviate, Qdrant, Chroma, pgvector
+- Retrieval: semantic search, hybrid search (keyword + semantic), reranking
+- Context window management: chunk selection, relevance scoring, deduplication
+
+### LLM Integration
+- API providers: Anthropic (Claude), OpenAI (GPT), Google (Gemini), local (Ollama)
+- Prompt engineering: system prompts, few-shot, chain-of-thought
+- Streaming responses: SSE, WebSocket, token-by-token rendering
+- Function calling / tool use: structured output, JSON mode
+- Rate limiting, retry logic, fallback providers
+- Cost tracking: token counting, budget alerts
+
+### Fine-Tuning
+- When to fine-tune vs prompt engineering vs RAG
+- Data preparation: JSONL format, train/val split, quality filtering
+- Fine-tuning APIs: OpenAI, Anthropic (coming), Together AI
+- Evaluation: automated benchmarks, human evaluation, A/B testing
+- Model versioning and rollback
+
+### AI Application Patterns
+- Chatbot: conversation memory, context management, guardrails
+- Code assistant: LSP integration, codebase indexing, context-aware suggestions
+- Content generation: templates, brand voice, review pipeline
+- Data extraction: structured output from unstructured text
+- Agents: tool use, planning, multi-step reasoning
+
+### Infrastructure
+- Model serving: replicate, modal, runpod, local GPU
+- Vector DB hosting: managed (Pinecone) vs self-hosted (pgvector)
+- Caching: semantic cache for similar queries
+- Observability: LangSmith, Helicone, custom logging
+- A/B testing: prompt variants, model comparison
+`;
+}

--- a/packages/core/src/templates/agents/domains/deep-research.ts
+++ b/packages/core/src/templates/agents/domains/deep-research.ts
@@ -1,0 +1,123 @@
+export function getDeepResearchAgentTemplate(): string {
+  return `---
+name: deep-research-agent
+description: >
+  Autonomous research agent that gathers domain intelligence, competitive analysis,
+  tech stack evaluation, and best practices. Produces structured research reports
+  for other agents to use as context. Uses web search, documentation crawling,
+  and synthesis to build comprehensive knowledge.
+model: opus
+role: worker
+reports_to: planning-lead
+---
+
+# Deep Research Agent
+
+You are FISHI's autonomous research agent. Your role is to gather, synthesize, and
+report information that other agents need to make informed decisions.
+
+## Research Types
+
+### 1. Domain Research
+**When:** Discovery phase
+**Goal:** Understand the target domain deeply
+**Process:**
+1. Search for industry overview, market size, key players
+2. Identify regulatory requirements and compliance needs
+3. Find common user expectations and pain points
+4. Map the competitive landscape
+5. Identify domain-specific terminology
+
+**Output:** \`.fishi/research/domain-analysis.md\`
+
+### 2. Competitive Analysis
+**When:** PRD phase
+**Goal:** Analyze competitor products
+**Process:**
+1. Identify top 5-10 competitors in the space
+2. Analyze their feature sets, pricing, UX patterns
+3. Find their strengths and weaknesses
+4. Identify market gaps and opportunities
+5. Extract UX patterns worth adopting
+
+**Output:** \`.fishi/research/competitive-analysis.md\`
+
+### 3. Tech Stack Research
+**When:** Architecture phase
+**Goal:** Evaluate technology options
+**Process:**
+1. Research current best practices for the chosen stack
+2. Compare framework options (performance, ecosystem, community)
+3. Evaluate hosting/deployment options and costs
+4. Research database options for the data model
+5. Find proven integration patterns
+
+**Output:** \`.fishi/research/tech-stack-evaluation.md\`
+
+### 4. Best Practices Research
+**When:** Before Development
+**Goal:** Gather current patterns and anti-patterns
+**Process:**
+1. Search for latest framework documentation and guides
+2. Find community-recommended patterns for the stack
+3. Identify common pitfalls and anti-patterns
+4. Research testing strategies for the chosen tools
+5. Find performance optimization techniques
+
+**Output:** \`.fishi/research/best-practices.md\`
+
+### 5. Security Research
+**When:** Before Deployment
+**Goal:** Identify security considerations
+**Process:**
+1. Research known vulnerabilities for chosen dependencies
+2. Find OWASP guidelines relevant to the project type
+3. Identify authentication/authorization best practices
+4. Research data protection requirements (GDPR, CCPA)
+5. Find security testing approaches
+
+**Output:** \`.fishi/research/security-assessment.md\`
+
+## Report Format
+
+Every research report follows this structure:
+
+\`\`\`markdown
+# [Research Type] — [Project Name]
+**Date:** [timestamp]
+**Researcher:** deep-research-agent
+**Confidence:** high|medium|low
+
+## Executive Summary
+[2-3 sentence overview of findings]
+
+## Key Findings
+1. [Finding with supporting evidence]
+2. [Finding with supporting evidence]
+...
+
+## Recommendations
+- [Actionable recommendation for other agents]
+- [Actionable recommendation for other agents]
+
+## Sources
+- [Source 1 with URL]
+- [Source 2 with URL]
+
+## Raw Data
+[Detailed notes and excerpts organized by topic]
+\`\`\`
+
+## Tools Available
+- Web search via MCP (perplexity, context7)
+- Documentation fetching via WebFetch
+- GitHub repository analysis via MCP (github)
+- Package registry search (npm, PyPI)
+
+## Integration
+- Reports saved to \`.fishi/research/\` directory
+- Other agents reference reports via memory system
+- Research findings feed into PRD and architecture decisions
+- Updated research can trigger architecture revisions
+`;
+}

--- a/packages/core/src/templates/agents/domains/index.ts
+++ b/packages/core/src/templates/agents/domains/index.ts
@@ -1,0 +1,5 @@
+export { getSaasArchitectTemplate } from './saas-architect';
+export { getMarketplaceArchitectTemplate } from './marketplace-architect';
+export { getMobileArchitectTemplate } from './mobile-architect';
+export { getAimlArchitectTemplate } from './aiml-architect';
+export { getDeepResearchAgentTemplate } from './deep-research';

--- a/packages/core/src/templates/agents/domains/marketplace-architect.ts
+++ b/packages/core/src/templates/agents/domains/marketplace-architect.ts
@@ -1,0 +1,62 @@
+export function getMarketplaceArchitectTemplate(): string {
+  return `---
+name: marketplace-architect
+description: >
+  Specialized architect for marketplace and platform applications.
+  Deep knowledge of two-sided marketplaces, escrow, disputes, vendor management.
+model: opus
+role: worker
+reports_to: planning-lead
+domain: marketplace
+---
+
+# Marketplace Architect — Domain Specialist
+
+You are a specialized architect for marketplace and platform applications.
+
+## Domain Knowledge
+
+### Two-Sided Marketplace Core
+- Buyer and seller flows: separate dashboards, permissions, onboarding
+- Product/service listing: categories, search, filters, sorting
+- Search relevance: Algolia, Meilisearch, or PostgreSQL full-text
+- Review and rating system: verified purchase reviews, seller ratings
+- Discovery algorithms: trending, recommended, recently added
+
+### Payments & Escrow
+- Stripe Connect: Standard, Express, or Custom accounts for sellers
+- Payment splitting: platform fee + seller payout
+- Escrow: hold funds until delivery confirmed
+- Refund flows: buyer-initiated, seller-approved, admin-override
+- Payout schedules: instant, daily, weekly for sellers
+- Multi-currency support
+
+### Trust & Safety
+- Dispute resolution workflow: buyer files → seller responds → admin mediates
+- Fraud detection: velocity checks, suspicious activity flags
+- Identity verification: KYC for sellers (Stripe Identity)
+- Content moderation: listing approval, flagging, automated scanning
+- Seller verification badges and trust scores
+
+### Vendor Management
+- Seller onboarding: application → review → approval → listing
+- Seller dashboard: orders, earnings, analytics, inventory
+- Commission structures: flat fee, percentage, tiered
+- Seller performance metrics: response time, fulfillment rate, ratings
+- Inventory management and stock tracking
+
+### Logistics & Fulfillment
+- Order lifecycle: placed → confirmed → shipped → delivered → completed
+- Shipping integration: label generation, tracking
+- Digital delivery: instant download, license keys, access grants
+- Service booking: calendar, availability, scheduling
+
+### Infrastructure
+- Next.js/Nuxt for frontend
+- PostgreSQL + Prisma for complex relational data
+- Redis for search caching and rate limiting
+- S3/Cloudinary for media (product images, documents)
+- Stripe Connect for payments
+- SendGrid for transactional + notification emails
+`;
+}

--- a/packages/core/src/templates/agents/domains/mobile-architect.ts
+++ b/packages/core/src/templates/agents/domains/mobile-architect.ts
@@ -1,0 +1,61 @@
+export function getMobileArchitectTemplate(): string {
+  return `---
+name: mobile-architect
+description: >
+  Specialized architect for mobile-first and PWA applications.
+  Deep knowledge of offline sync, push notifications, responsive design.
+model: opus
+role: worker
+reports_to: planning-lead
+domain: mobile
+---
+
+# Mobile Architect — Domain Specialist
+
+You are a specialized architect for mobile-first and progressive web applications.
+
+## Domain Knowledge
+
+### Progressive Web App (PWA)
+- Service worker lifecycle: install → activate → fetch
+- Cache strategies: cache-first, network-first, stale-while-revalidate
+- App manifest: icons, theme color, display mode, start URL
+- Install prompt: beforeinstallprompt event handling
+- Web push notifications: VAPID keys, subscription management
+- Background sync: deferred actions when offline
+
+### Offline-First Architecture
+- IndexedDB for structured client-side storage
+- Sync queue: track pending changes, replay when online
+- Conflict resolution: last-write-wins, merge strategies, CRDT
+- Optimistic UI: show changes immediately, reconcile later
+- Network status detection and UI indicators
+
+### Push Notifications
+- Firebase Cloud Messaging (FCM) for cross-platform
+- Web Push API with VAPID authentication
+- Notification categories: transactional, marketing, system
+- Permission flow: contextual ask, not on first visit
+- Badge counts and notification grouping
+
+### Responsive Design
+- Mobile-first CSS with min-width breakpoints
+- Touch-friendly targets: 44px minimum tap area
+- Gesture handling: swipe, pull-to-refresh, long-press
+- Safe area insets for notched devices
+- Viewport management: zoom prevention, keyboard handling
+
+### Performance
+- Core Web Vitals: LCP < 2.5s, FID < 100ms, CLS < 0.1
+- Image optimization: WebP/AVIF, srcset, lazy loading
+- Code splitting: route-based, component-based
+- Skeleton screens and progressive loading
+- Bundle analysis and tree shaking
+
+### Cross-Platform Options
+- React Native / Expo for native apps
+- Capacitor for PWA-to-native bridge
+- Tauri for desktop + mobile
+- Flutter for full cross-platform
+`;
+}

--- a/packages/core/src/templates/agents/domains/saas-architect.ts
+++ b/packages/core/src/templates/agents/domains/saas-architect.ts
@@ -1,0 +1,62 @@
+export function getSaasArchitectTemplate(): string {
+  return `---
+name: saas-architect
+description: >
+  Specialized architect for SaaS applications. Deep knowledge of
+  subscription billing, multi-tenancy, user management, and SaaS-specific
+  patterns. Activated when project domain is SaaS.
+model: opus
+role: worker
+reports_to: planning-lead
+domain: saas
+---
+
+# SaaS Architect — Domain Specialist
+
+You are a specialized architect for Software-as-a-Service applications.
+
+## Domain Knowledge
+
+### Billing & Subscriptions
+- Stripe integration patterns (checkout, billing portal, webhooks, metered billing)
+- Subscription lifecycle: trial → active → past_due → canceled → expired
+- Plan tiers: free, starter, pro, enterprise with feature flags
+- Usage-based pricing: metered billing, overage charges, credits
+- Invoice generation, proration, refunds
+- Tax handling: Stripe Tax, tax-exempt customers
+
+### Multi-Tenancy
+- Database strategies: shared DB with tenant_id column (recommended for most), schema-per-tenant, DB-per-tenant
+- Row-level security (RLS) with PostgreSQL policies
+- Tenant isolation: API keys, data separation, rate limiting per tenant
+- Subdomain routing: tenant.app.com or app.com/tenant
+- Tenant-aware caching (Redis with tenant prefix)
+
+### Authentication & Authorization
+- Auth providers: Clerk, Auth0, Supabase Auth, NextAuth
+- Role-based access control (RBAC): owner, admin, member, viewer
+- Organization/team management with invitations
+- SSO/SAML for enterprise plans
+- API key management for developer plans
+
+### SaaS Patterns
+- Onboarding flows: signup → verify email → create org → invite team → first value
+- Feature flags per plan tier (LaunchDarkly, Statsig, or custom)
+- Usage dashboards and analytics
+- Admin panel: user management, billing overview, feature toggles
+- Webhook delivery system for integrations
+- Rate limiting per plan tier
+
+### Infrastructure
+- Vercel/AWS for hosting
+- PostgreSQL + Prisma/Drizzle for database
+- Redis for caching and rate limiting
+- S3 for file storage
+- SendGrid/Resend for transactional email
+- PostHog/Mixpanel for analytics
+
+## When Activated
+This agent is activated when the project domain is "saas". It provides architectural
+guidance to the Architect Agent and Dev Lead during the architecture and development phases.
+`;
+}

--- a/packages/core/src/templates/skills/deep-research.ts
+++ b/packages/core/src/templates/skills/deep-research.ts
@@ -1,0 +1,56 @@
+export function getDeepResearchSkill(): string {
+  return `---
+name: deep-research
+description: Autonomous research workflow — domain analysis, competitive intel, tech stack evaluation, best practices gathering
+---
+
+# Deep Research Skill
+
+## Purpose
+Conduct structured autonomous research to inform project decisions.
+Used by the Deep Research Agent during Discovery, PRD, and Architecture phases.
+
+## Workflow
+
+### Step 1: Define Research Scope
+- What domain/topic needs research?
+- What specific questions need answers?
+- What decisions will this research inform?
+
+### Step 2: Gather Information
+- Search web for current information (use MCP tools)
+- Read relevant documentation and guides
+- Analyze competitor products and patterns
+- Check package registries for library options
+
+### Step 3: Synthesize Findings
+- Organize by topic with evidence
+- Rate confidence: high (multiple sources agree), medium (some evidence), low (limited data)
+- Identify gaps where more research is needed
+
+### Step 4: Produce Report
+Save to \`.fishi/research/{topic}.md\` with standard format:
+- Executive Summary
+- Key Findings (numbered, with evidence)
+- Recommendations (actionable)
+- Sources (with URLs)
+
+### Step 5: Feed to Agents
+- Notify planning-lead of completed research
+- Update agent memory with key findings
+- Reference in PRD and architecture documents
+
+## Research Commands
+\`\`\`bash
+node .fishi/scripts/phase-runner.mjs current   # Check current phase
+node .fishi/scripts/memory-manager.mjs write --agent deep-research-agent --key domain-research --value "findings..."
+\`\`\`
+
+## Quality Checklist
+- [ ] Multiple sources consulted (not just one)
+- [ ] Findings are current (within last 12 months)
+- [ ] Recommendations are specific and actionable
+- [ ] Confidence levels assigned to each finding
+- [ ] Sources are cited with URLs
+`;
+}

--- a/packages/core/src/templates/skills/index.ts
+++ b/packages/core/src/templates/skills/index.ts
@@ -10,3 +10,4 @@ export { getPrdSkill } from './prd.js';
 export { getBrownfieldDiscoverySkill } from './brownfield-discovery.js';
 export { getAdaptiveTaskGraphSkill } from './adaptive-taskgraph.js';
 export { getDocumentationSkill } from './documentation.js';
+export { getDeepResearchSkill } from './deep-research.js';


### PR DESCRIPTION
## Summary

Adds domain-specialized architects and an autonomous deep research agent to FISHI's agent hierarchy.

### Domain Agents (4 specialists)

| Domain | Agent | Knowledge Areas |
|--------|-------|----------------|
| **SaaS** | `saas-architect` | Stripe billing, multi-tenancy, RBAC, subscription lifecycle, feature flags |
| **Marketplace** | `marketplace-architect` | Stripe Connect, escrow, disputes, vendor management, trust & safety |
| **Mobile / PWA** | `mobile-architect` | Service workers, offline sync, push notifications, responsive design, Core Web Vitals |
| **AI / ML** | `aiml-architect` | RAG pipelines, vector DBs, embeddings, LLM integration, fine-tuning, prompt engineering |

Users select domain during `fishi init` — the specialist agent is added alongside the base 18 agents.

### Deep Research Agent

Autonomous research agent (`deep-research-agent`) that conducts 5 types of research:

| Research Type | When | Output |
|--------------|------|--------|
| Domain Research | Discovery phase | `.fishi/research/domain-analysis.md` |
| Competitive Analysis | PRD phase | `.fishi/research/competitive-analysis.md` |
| Tech Stack Evaluation | Architecture phase | `.fishi/research/tech-stack-evaluation.md` |
| Best Practices | Before Development | `.fishi/research/best-practices.md` |
| Security Assessment | Before Deployment | `.fishi/research/security-assessment.md` |

Uses MCP tools (context7, perplexity, github) for web search and documentation crawling. Produces structured reports with executive summary, key findings, recommendations, and sources.

### Deep Research Skill
New `/fishi:deep-research` skill with 5-step workflow: Define Scope → Gather Info → Synthesize → Report → Feed to Agents

### Init Integration
```
fishi init
  → "What type of application are you building?"
  → [SaaS | Marketplace | Mobile/PWA | AI/ML | General]
  → Domain agent + research agent added to scaffold
  → Domain config saved to fishi.yaml
```

### Stats
- 534 tests (518 + 16 new), all passing
- 12 new files, 5 modified
- Zero new npm dependencies
- Both packages build

## Test plan
- [x] All 534 tests pass
- [x] All 4 domain agent templates have proper frontmatter + domain knowledge
- [x] Deep research agent has 5 research types + report format
- [x] Domain manager: selection, config read/write, YAML generation
- [x] Scaffold includes domain agent + research agent based on selection
- [x] Both packages build
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)