### PR TITLE
feat: Three-Layer Agent Safety — SOUL.md, AGENTS.md, per-role permissions

### DIFF
--- a/packages/core/src/__tests__/agent-permissions.test.ts
+++ b/packages/core/src/__tests__/agent-permissions.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPermissionsForRole,
+  getAllPermissionSummary,
+  generatePermissionBlock,
+} from '../generators/agent-permissions';
+
+describe('Agent Permissions', () => {
+  describe('getPermissionsForRole', () => {
+    it('master has read-only + delegation, no write/edit/bash', () => {
+      const perms = getPermissionsForRole('master');
+      expect(perms.role).toBe('master');
+      expect(perms.allow).toContain('Read');
+      expect(perms.allow).toContain('Agent');
+      expect(perms.allow).not.toContain('Write');
+      expect(perms.allow).not.toContain('Edit');
+      expect(perms.deny).toContain('Write');
+      expect(perms.deny).toContain('Edit');
+      expect(perms.deny).toContain('Bash(*)');
+    });
+
+    it('coordinator has read/write but no force push or merge to main', () => {
+      const perms = getPermissionsForRole('coordinator');
+      expect(perms.allow).toContain('Read');
+      expect(perms.allow).toContain('Write');
+      expect(perms.allow).toContain('Edit');
+      expect(perms.deny).toContain('Bash(git push --force *)');
+      expect(perms.deny).toContain('Bash(git push * main)');
+    });
+
+    it('worker has full dev but no merge, no push to main, no destructive commands', () => {
+      const perms = getPermissionsForRole('worker');
+      expect(perms.allow).toContain('Write');
+      expect(perms.allow).toContain('Edit');
+      expect(perms.allow).toContain('Bash(node *)');
+      expect(perms.allow).toContain('Bash(npx *)');
+      expect(perms.deny).toContain('Bash(git merge *)');
+      expect(perms.deny).toContain('Bash(rm -rf *)');
+      expect(perms.deny).toContain('Bash(sudo *)');
+    });
+
+    it('all roles deny npm (enforce pnpm)', () => {
+      for (const role of ['master', 'coordinator', 'worker'] as const) {
+        const perms = getPermissionsForRole(role);
+        expect(perms.deny).toContain('Bash(npm *)');
+      }
+    });
+
+    it('all roles deny sudo and shutdown', () => {
+      for (const role of ['coordinator', 'worker'] as const) {
+        const perms = getPermissionsForRole(role);
+        expect(perms.deny).toContain('Bash(sudo *)');
+        expect(perms.deny).toContain('Bash(shutdown *)');
+      }
+    });
+  });
+
+  describe('getAllPermissionSummary', () => {
+    it('returns counts for all three roles', () => {
+      const summary = getAllPermissionSummary();
+      expect(summary.master.allowCount).toBeGreaterThan(0);
+      expect(summary.master.denyCount).toBeGreaterThan(0);
+      expect(summary.coordinator.allowCount).toBeGreaterThan(summary.master.allowCount);
+      expect(summary.worker.allowCount).toBeGreaterThan(summary.coordinator.allowCount);
+    });
+
+    it('master has fewest permissions', () => {
+      const summary = getAllPermissionSummary();
+      expect(summary.master.allowCount).toBeLessThan(summary.coordinator.allowCount);
+      expect(summary.master.allowCount).toBeLessThan(summary.worker.allowCount);
+    });
+  });
+
+  describe('generatePermissionBlock', () => {
+    it('generates valid YAML-like permission block', () => {
+      const block = generatePermissionBlock('worker');
+      expect(block).toContain('role: worker');
+      expect(block).toContain('allow:');
+      expect(block).toContain('deny:');
+      expect(block).toContain('"Read"');
+    });
+  });
+});

--- a/packages/core/src/__tests__/safety-templates.test.ts
+++ b/packages/core/src/__tests__/safety-templates.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { getSoulMdTemplate } from '../templates/configs/soul-md';
+import { getAgentsMdTemplate } from '../templates/configs/agents-md';
+
+describe('Safety Templates', () => {
+  describe('SOUL.md', () => {
+    it('contains core principles', () => {
+      const soul = getSoulMdTemplate();
+      expect(soul).toContain('Human authority is final');
+      expect(soul).toContain('Reversibility first');
+      expect(soul).toContain('Least privilege');
+      expect(soul).toContain('Transparency');
+    });
+
+    it('defines absolute boundaries', () => {
+      const soul = getSoulMdTemplate();
+      expect(soul).toContain('Never Do Autonomously');
+      expect(soul).toContain('Delete files');
+      expect(soul).toContain('Push code to production');
+      expect(soul).toContain('Modify environment variables');
+    });
+
+    it('defines confirmation requirements', () => {
+      const soul = getSoulMdTemplate();
+      expect(soul).toContain('Always Require Human Confirmation');
+      expect(soul).toContain('Merging branches');
+      expect(soul).toContain('Deploying');
+    });
+
+    it('references enforcement layers', () => {
+      const soul = getSoulMdTemplate();
+      expect(soul).toContain('SOUL.md');
+      expect(soul).toContain('AGENTS.md');
+      expect(soul).toContain('Tool permissions');
+    });
+  });
+
+  describe('AGENTS.md', () => {
+    it('defines role hierarchy', () => {
+      const agents = getAgentsMdTemplate();
+      expect(agents).toContain('Level 0: Master Orchestrator');
+      expect(agents).toContain('Level 1: Coordinators');
+      expect(agents).toContain('Level 2: Workers');
+    });
+
+    it('master cannot write or edit', () => {
+      const agents = getAgentsMdTemplate();
+      expect(agents).toContain('Write/Edit files');
+      expect(agents).toContain('DENIED');
+    });
+
+    it('defines destructive action protocol', () => {
+      const agents = getAgentsMdTemplate();
+      expect(agents).toContain('Destructive Action Protocol');
+      expect(agents).toContain('Never delete');
+      expect(agents).toContain('.fishi/archive/');
+    });
+
+    it('defines escalation path', () => {
+      const agents = getAgentsMdTemplate();
+      expect(agents).toContain('Escalation Path');
+      expect(agents).toContain('human confirmation');
+    });
+
+    it('defines emergency stop', () => {
+      const agents = getAgentsMdTemplate();
+      expect(agents).toContain('Emergency Stop');
+      expect(agents).toContain('safety.violation');
+      expect(agents).toContain('safety-incidents.log');
+    });
+  });
+});

--- a/packages/core/src/generators/agent-permissions.ts
+++ b/packages/core/src/generators/agent-permissions.ts
@@ -1,0 +1,176 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export type AgentRole = 'master' | 'coordinator' | 'worker';
+
+export interface AgentPermissionSet {
+  role: AgentRole;
+  allow: string[];
+  deny: string[];
+}
+
+/**
+ * Get tool permissions for a specific agent role.
+ * Master: read-only + delegation. Coordinators: read/write + git. Workers: full dev in sandbox.
+ */
+export function getPermissionsForRole(role: AgentRole): AgentPermissionSet {
+  switch (role) {
+    case 'master':
+      return {
+        role: 'master',
+        allow: [
+          'Read',
+          'Glob',
+          'Grep',
+          'Agent',
+          'TodoRead',
+          'TodoWrite',
+          'WebFetch',
+          'WebSearch',
+        ],
+        deny: [
+          'Write',
+          'Edit',
+          'Bash(*)',
+          'NotebookEdit',
+          'Bash(rm *)',
+          'Bash(git push *)',
+          'Bash(git merge *)',
+          'Bash(npm *)',
+          'Bash(pnpm *)',
+        ],
+      };
+
+    case 'coordinator':
+      return {
+        role: 'coordinator',
+        allow: [
+          'Read',
+          'Write',
+          'Edit',
+          'Glob',
+          'Grep',
+          'Agent',
+          'TodoRead',
+          'TodoWrite',
+          'WebFetch',
+          'WebSearch',
+          'Bash(git status *)',
+          'Bash(git log *)',
+          'Bash(git diff *)',
+          'Bash(git branch *)',
+          'Bash(git checkout *)',
+          'Bash(git worktree *)',
+          'Bash(node *)',
+          'Bash(npx vitest *)',
+          'Bash(npx tsc *)',
+          'Bash(pnpm install *)',
+          'Bash(pnpm add *)',
+          'Bash(cat *)',
+          'Bash(ls *)',
+          'Bash(find *)',
+        ],
+        deny: [
+          'Bash(rm -rf *)',
+          'Bash(git push --force *)',
+          'Bash(git push * main)',
+          'Bash(git push * master)',
+          'Bash(git push * production)',
+          'Bash(git merge * main)',
+          'Bash(git merge * master)',
+          'Bash(sudo *)',
+          'Bash(chmod *)',
+          'Bash(shutdown *)',
+          'Bash(mkfs *)',
+          'Bash(dd *)',
+          'Bash(npm *)',
+        ],
+      };
+
+    case 'worker':
+      return {
+        role: 'worker',
+        allow: [
+          'Read',
+          'Write',
+          'Edit',
+          'Glob',
+          'Grep',
+          'Agent',
+          'TodoRead',
+          'TodoWrite',
+          'WebFetch',
+          'WebSearch',
+          'Bash(node *)',
+          'Bash(npx *)',
+          'Bash(pnpm *)',
+          'Bash(git add *)',
+          'Bash(git commit *)',
+          'Bash(git status *)',
+          'Bash(git log *)',
+          'Bash(git diff *)',
+          'Bash(tsc *)',
+          'Bash(eslint *)',
+          'Bash(prettier *)',
+          'Bash(cat *)',
+          'Bash(ls *)',
+          'Bash(find *)',
+          'Bash(grep *)',
+          'Bash(wc *)',
+          'Bash(head *)',
+          'Bash(tail *)',
+          'Bash(sort *)',
+          'Bash(mkdir *)',
+          'Bash(cp *)',
+          'Bash(mv *)',
+        ],
+        deny: [
+          'Bash(rm -rf *)',
+          'Bash(rm -r /)',
+          'Bash(git push --force *)',
+          'Bash(git push * main)',
+          'Bash(git push * master)',
+          'Bash(git push * production)',
+          'Bash(git merge *)',
+          'Bash(git branch -D *)',
+          'Bash(sudo *)',
+          'Bash(chmod 777 *)',
+          'Bash(shutdown *)',
+          'Bash(reboot *)',
+          'Bash(mkfs *)',
+          'Bash(dd *)',
+          'Bash(kill -9 *)',
+          'Bash(pkill *)',
+          'Bash(npm *)',
+          'Bash(curl * | sh)',
+          'Bash(wget * | sh)',
+        ],
+      };
+  }
+}
+
+/**
+ * Get all permission sets as a summary for display.
+ */
+export function getAllPermissionSummary(): Record<AgentRole, { allowCount: number; denyCount: number }> {
+  const roles: AgentRole[] = ['master', 'coordinator', 'worker'];
+  const result: Record<string, { allowCount: number; denyCount: number }> = {};
+  for (const role of roles) {
+    const perms = getPermissionsForRole(role);
+    result[role] = { allowCount: perms.allow.length, denyCount: perms.deny.length };
+  }
+  return result as Record<AgentRole, { allowCount: number; denyCount: number }>;
+}
+
+/**
+ * Generate per-agent permission YAML block for settings.json or agent definition.
+ */
+export function generatePermissionBlock(role: AgentRole): string {
+  const perms = getPermissionsForRole(role);
+  const allowLines = perms.allow.map(r => `    - "${r}"`).join('\n');
+  const denyLines = perms.deny.map(r => `    - "${r}"`).join('\n');
+  return `permissions:
+  role: ${role}
+  allow:\n${allowLines}
+  deny:\n${denyLines}`;
+}

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -15,3 +15,5 @@ export { detectDesignTokens, generateDefaultTokens, detectComponentRegistry, run
 export type { DesignTokens, ComponentEntry, ComponentRegistry, BrandGuardianIssue, BrandGuardianReport } from './design-system';
 export { getAvailableDomains, readDomainConfig, getDomainConfigYaml, DOMAIN_INFO } from './domain-manager';
 export type { ProjectDomain, DomainConfig } from './domain-manager';
+export { getPermissionsForRole, getAllPermissionSummary, generatePermissionBlock } from './agent-permissions';
+export type { AgentRole, AgentPermissionSet } from './agent-permissions';

--- a/packages/core/src/generators/scaffold.ts
+++ b/packages/core/src/generators/scaffold.ts
@@ -92,6 +92,8 @@ import { getProjectYamlTemplate } from '../templates/configs/project-yaml.js';
 import { getAgentRegistryTemplate } from '../templates/configs/agent-registry.js';
 import { getGitignoreAdditions } from '../templates/configs/gitignore-additions.js';
 import { getModelRoutingReference } from '../templates/configs/model-routing.js';
+import { getSoulMdTemplate } from '../templates/configs/soul-md.js';
+import { getAgentsMdTemplate } from '../templates/configs/agents-md.js';
 
 export type ConflictResolution = 'skip' | 'merge' | 'replace';
 
@@ -185,6 +187,7 @@ export async function generateScaffold(
     '.fishi/todos/agents',
     '.fishi/learnings/by-domain',
     '.fishi/learnings/by-agent',
+    '.fishi/archive',
     '.fishi/research',
     '.trees',
   ];
@@ -295,6 +298,10 @@ export async function generateScaffold(
   await write('.claude/commands/fishi-reset.md', getResetCommand(), 'commands');
   await write('.claude/commands/fishi-prd.md', getPrdCommand(), 'commands');
   const commandCount = 8;
+
+  // ── Safety Layer ────────────────────────────────────────────────
+  await write('SOUL.md', getSoulMdTemplate());
+  await write('AGENTS.md', getAgentsMdTemplate());
 
   // ── Config Files ──────────────────────────────────────────────────
   await write('.fishi/fishi.yaml', getFishiYamlTemplate({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,3 +159,7 @@ export type { ProjectDomain, DomainConfig } from './generators/index';
 export { getSandboxPolicyTemplate } from './templates/configs/sandbox-policy';
 export { getDockerfileTemplate } from './templates/docker/Dockerfile';
 export { getDashboardHtml } from './templates/dashboard/index-html';
+export { getPermissionsForRole, getAllPermissionSummary, generatePermissionBlock } from './generators/index';
+export type { AgentRole as AgentPermissionRole, AgentPermissionSet } from './generators/index';
+export { getSoulMdTemplate } from './templates/configs/soul-md';
+export { getAgentsMdTemplate } from './templates/configs/agents-md';

--- a/packages/core/src/templates/configs/agents-md.ts
+++ b/packages/core/src/templates/configs/agents-md.ts
@@ -1,0 +1,92 @@
+export function getAgentsMdTemplate(): string {
+  return `# AGENTS.md — FISHI Role-Based Action Gates
+
+> Maps which actions require approval per agent role.
+> Read alongside SOUL.md for complete safety configuration.
+
+## Role Hierarchy
+
+\`\`\`
+Level 0: Master Orchestrator — strategy only, no code, no file writes
+Level 1: Coordinators — task assignment, code review, limited writes
+Level 2: Workers — full dev within worktree, no merge, no deploy
+\`\`\`
+
+## Action Permissions by Role
+
+### Master Orchestrator (L0)
+| Action | Permission |
+|--------|-----------|
+| Read files | Allowed |
+| Write/Edit files | **DENIED** — delegates to coordinators |
+| Run shell commands | **DENIED** — delegates to workers |
+| Approve gates | Allowed (with human confirmation) |
+| Assign tasks | Allowed |
+| Create agents | Allowed (dynamic agent factory) |
+| Merge branches | **DENIED** — requires human gate approval |
+| Deploy | **DENIED** — requires deployment gate |
+| Delete files | **DENIED** |
+
+### Coordinators (L1)
+| Action | Permission |
+|--------|-----------|
+| Read files | Allowed |
+| Write/Edit files | Allowed (planning docs, task assignments) |
+| Run shell commands | Allowed (git status, test runs, non-destructive) |
+| Approve worker PRs | Allowed (code review) |
+| Create worktrees | Allowed |
+| Merge to dev branch | Allowed (after review) |
+| Merge to main/production | **DENIED** — requires gate |
+| Delete files | **DENIED** — archive instead |
+| Install dependencies | Allowed (within sandbox) |
+| Modify configs | **REQUIRES CONFIRMATION** |
+
+### Workers (L2)
+| Action | Permission |
+|--------|-----------|
+| Read files | Allowed (within worktree + shared) |
+| Write/Edit files | Allowed (within worktree only) |
+| Run shell commands | Allowed (within worktree sandbox) |
+| Run tests | Allowed |
+| Install dev dependencies | Allowed (within sandbox) |
+| Commit to worktree branch | Allowed |
+| Push to worktree branch | Allowed |
+| Merge branches | **DENIED** — submit PR to coordinator |
+| Delete files | **DENIED** — request via coordinator |
+| Access main branch | **READ ONLY** |
+| External API calls | **DENIED** — unless in sandbox allowlist |
+
+## Destructive Action Protocol
+
+### Delete Operations
+1. **Files:** Never delete. Move to \`.fishi/archive/\` with timestamp.
+2. **Branches:** Only after merge confirmed + worktree cleaned.
+3. **Database records:** Never in production. Soft-delete only.
+4. **Dependencies:** Remove only via coordinator approval.
+
+### Archive Instead of Delete
+\`\`\`
+Instead of: rm -rf old-feature/
+Do:         mv old-feature/ .fishi/archive/old-feature-{timestamp}/
+\`\`\`
+
+### Escalation Path
+\`\`\`
+Worker encounters destructive need
+  → Reports to Coordinator
+    → Coordinator evaluates risk
+      → If safe: Coordinator executes with logging
+      → If risky: Escalate to Master
+        → Master requests human confirmation via gate
+\`\`\`
+
+## Emergency Stop
+
+If any agent detects behavior outside these boundaries:
+1. Log the incident to \`.fishi/logs/safety-incidents.log\`
+2. Emit \`safety.violation\` event to monitor
+3. Notify master-orchestrator
+4. Halt the violating agent's current task
+5. Wait for human review before resuming
+`;
+}

--- a/packages/core/src/templates/configs/index.ts
+++ b/packages/core/src/templates/configs/index.ts
@@ -16,3 +16,6 @@ export { getAgentRegistryTemplate } from './agent-registry';
 export { getGitignoreAdditions } from './gitignore-additions';
 
 export { getModelRoutingReference } from './model-routing';
+
+export { getSoulMdTemplate } from './soul-md';
+export { getAgentsMdTemplate } from './agents-md';

--- a/packages/core/src/templates/configs/soul-md.ts
+++ b/packages/core/src/templates/configs/soul-md.ts
@@ -1,0 +1,58 @@
+export function getSoulMdTemplate(): string {
+  return `# SOUL.md — FISHI Agent Boundaries
+
+> This file defines absolute boundaries that NO agent may cross autonomously.
+> These rules override all other instructions, skills, and commands.
+
+## Core Principles
+
+1. **Human authority is final.** Agents assist; humans decide.
+2. **Reversibility first.** Prefer reversible actions. Irreversible actions require human confirmation.
+3. **Least privilege.** Agents operate with minimum necessary access.
+4. **Transparency.** All agent actions are logged and observable.
+
+## Absolute Boundaries
+
+### Never Do Autonomously
+- Delete files, directories, or data without explicit human approval
+- Push code to production branches (main, master, production) without gate approval
+- Modify environment variables, secrets, or credentials
+- Make external API calls to services not in the sandbox allowlist
+- Install global packages or modify system configuration
+- Access files outside the assigned worktree (workers)
+- Execute shell commands that affect other users or processes
+- Disable safety hooks, permission rules, or gate requirements
+- Bypass the phase pipeline or skip mandatory gates
+- Send emails, messages, or notifications to external services
+- Access or transmit user personal data
+- Modify CI/CD pipelines without human review
+
+### Always Require Human Confirmation
+- Merging branches into main/dev
+- Deploying to any environment (staging, production)
+- Adding new external dependencies
+- Changing database schemas
+- Modifying authentication/authorization logic
+- Creating or modifying API endpoints that handle user data
+- Any action flagged by the security agent
+
+### Always Do
+- Log all significant actions to .fishi/logs/
+- Emit monitoring events via monitor-emitter
+- Work within assigned worktree boundaries
+- Follow the phase pipeline sequence
+- Submit work as PRs for review
+- Run tests before submitting work
+- Check sandbox policy before external access
+
+## Enforcement
+
+These boundaries are enforced at three levels:
+1. **SOUL.md** (this file) — read by all agents at session start
+2. **AGENTS.md** — per-role action gates
+3. **Tool permissions** — per-agent allow/deny lists in settings.json
+
+Violation of these boundaries should be reported to the master-orchestrator
+and logged as a critical learnings entry.
+`;
+}


### PR DESCRIPTION
## Summary

Implements a three-layer safety model inspired by the OpenClaw incident prevention framework. Ensures no FISHI agent can take irreversible actions autonomously.

### Layer 1: SOUL.md — Absolute Boundaries
Generated at project root. Defines what agents must **NEVER** do:
- No data deletion without human approval
- No production pushes without gate approval
- No credential access outside sandbox policy
- No disabling safety hooks or gate requirements

### Layer 2: AGENTS.md — Role-Based Action Gates
Maps destructive actions to approval requirements per role:

| Role | Can Do | Cannot Do |
|------|--------|-----------|
| Master (L0) | Read, delegate, approve gates | Write code, run shell, merge, deploy |
| Coordinators (L1) | Read/write, git ops, review PRs | Force push, merge to main, delete |
| Workers (L2) | Full dev in worktree sandbox | Merge, push to main, delete, sudo |

Includes: Destructive Action Protocol (archive instead of delete), Escalation Path (worker → coordinator → master → human), Emergency Stop procedures.

### Layer 3: Per-Agent Tool Permissions
Graduated access by role:

| Role | Allow | Deny |
|------|-------|------|
| Master | 8 tools (Read, Agent, Todo...) | 9 rules (no Write, Edit, Bash) |
| Coordinator | 24 tools (Read, Write, git ops...) | 13 rules (no force push, no main merge) |
| Worker | 32 tools (full dev toolkit) | 19 rules (no merge, no rm -rf, no sudo) |

All roles deny `npm` (enforce pnpm), `sudo`, production pushes.

### Files Generated During Scaffold
- `SOUL.md` — at project root (read by Claude Code at startup)
- `AGENTS.md` — at project root
- `.fishi/archive/` — directory for archived files (delete → archive)

### Stats
- 551 tests (534 + 17 new), all passing
- Zero new dependencies
- Both packages build

## Test plan
- [x] All 551 tests pass
- [x] SOUL.md: core principles, boundaries, confirmation requirements
- [x] AGENTS.md: role hierarchy, action mapping, escalation, emergency stop
- [x] Permissions: master < coordinator < worker access levels
- [x] All roles deny npm, sudo, shutdown
- [x] Scaffold creates SOUL.md + AGENTS.md + archive directory
- [x] Both packages build
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)