### PR TITLE
feat: Worktree Conflict Prevention — file lock registry + overlap detection

### DIFF
--- a/packages/core/src/__tests__/file-lock-manager.test.ts
+++ b/packages/core/src/__tests__/file-lock-manager.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  readFileLocks,
+  checkLockConflicts,
+  acquireLocks,
+  releaseLocks,
+  getAgentLocks,
+  getLockSummary,
+} from '../generators/file-lock-manager';
+
+describe('File Lock Manager', () => {
+  let tempDir: string;
+
+  function createTempDir(): string {
+    tempDir = mkdtempSync(join(tmpdir(), 'fishi-locks-'));
+    mkdirSync(join(tempDir, '.fishi', 'state'), { recursive: true });
+    return tempDir;
+  }
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('readFileLocks', () => {
+    it('returns empty array when no locks file', () => {
+      const dir = createTempDir();
+      expect(readFileLocks(dir)).toEqual([]);
+    });
+  });
+
+  describe('acquireLocks', () => {
+    it('acquires locks on unlocked files', () => {
+      const dir = createTempDir();
+      const result = acquireLocks(dir, ['src/auth.ts', 'src/login.tsx'], 'backend-agent', 'auth-feature', 'dev-lead');
+      expect(result.success).toBe(true);
+      expect(result.locked).toEqual(['src/auth.ts', 'src/login.tsx']);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it('persists locks to disk', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/app.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      const locks = readFileLocks(dir);
+      expect(locks).toHaveLength(1);
+      expect(locks[0].file).toBe('src/app.ts');
+      expect(locks[0].agent).toBe('backend-agent');
+      expect(locks[0].task).toBe('task-1');
+      expect(locks[0].coordinator).toBe('dev-lead');
+      expect(locks[0].lockedAt).toBeTruthy();
+    });
+
+    it('fails when file is locked by another agent', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/shared.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      const result = acquireLocks(dir, ['src/shared.ts'], 'frontend-agent', 'task-2', 'dev-lead');
+      expect(result.success).toBe(false);
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].file).toBe('src/shared.ts');
+      expect(result.conflicts[0].lockedBy).toBe('backend-agent');
+      expect(result.conflicts[0].requestingAgent).toBe('frontend-agent');
+    });
+
+    it('allows same agent to re-lock same file', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/app.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      const result = acquireLocks(dir, ['src/app.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      expect(result.success).toBe(true);
+      // Should not duplicate the lock
+      const locks = readFileLocks(dir);
+      expect(locks.filter(l => l.file === 'src/app.ts')).toHaveLength(1);
+    });
+
+    it('detects partial conflicts (some files locked, some free)', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts'], 'agent-1', 'task-1', 'dev-lead');
+      const result = acquireLocks(dir, ['src/a.ts', 'src/b.ts'], 'agent-2', 'task-2', 'dev-lead');
+      expect(result.success).toBe(false);
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].file).toBe('src/a.ts');
+    });
+
+    it('handles multiple agents locking different files', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/auth.ts'], 'backend-agent', 'auth', 'dev-lead');
+      const result = acquireLocks(dir, ['src/ui.tsx'], 'frontend-agent', 'ui', 'dev-lead');
+      expect(result.success).toBe(true);
+      const locks = readFileLocks(dir);
+      expect(locks).toHaveLength(2);
+    });
+  });
+
+  describe('checkLockConflicts', () => {
+    it('returns empty for no conflicts', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts'], 'agent-1', 'task-1', 'dev-lead');
+      const conflicts = checkLockConflicts(dir, ['src/b.ts'], 'agent-2', 'task-2');
+      expect(conflicts).toHaveLength(0);
+    });
+
+    it('returns conflicts when files overlap', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/shared.ts'], 'agent-1', 'task-1', 'dev-lead');
+      const conflicts = checkLockConflicts(dir, ['src/shared.ts'], 'agent-2', 'task-2');
+      expect(conflicts).toHaveLength(1);
+    });
+  });
+
+  describe('releaseLocks', () => {
+    it('releases all locks for an agent', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts', 'src/b.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      const released = releaseLocks(dir, 'backend-agent');
+      expect(released).toEqual(['src/a.ts', 'src/b.ts']);
+      expect(readFileLocks(dir)).toHaveLength(0);
+    });
+
+    it('releases only locks for specific task', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      acquireLocks(dir, ['src/b.ts'], 'backend-agent', 'task-2', 'dev-lead');
+      const released = releaseLocks(dir, 'backend-agent', 'task-1');
+      expect(released).toEqual(['src/a.ts']);
+      expect(readFileLocks(dir)).toHaveLength(1);
+    });
+
+    it('does not affect other agents locks', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts'], 'agent-1', 'task-1', 'dev-lead');
+      acquireLocks(dir, ['src/b.ts'], 'agent-2', 'task-2', 'dev-lead');
+      releaseLocks(dir, 'agent-1');
+      const locks = readFileLocks(dir);
+      expect(locks).toHaveLength(1);
+      expect(locks[0].agent).toBe('agent-2');
+    });
+  });
+
+  describe('getAgentLocks', () => {
+    it('returns locks for specific agent', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts', 'src/b.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      acquireLocks(dir, ['src/c.ts'], 'frontend-agent', 'task-2', 'dev-lead');
+      const locks = getAgentLocks(dir, 'backend-agent');
+      expect(locks).toHaveLength(2);
+    });
+  });
+
+  describe('getLockSummary', () => {
+    it('returns correct summary', () => {
+      const dir = createTempDir();
+      acquireLocks(dir, ['src/a.ts', 'src/b.ts'], 'backend-agent', 'task-1', 'dev-lead');
+      acquireLocks(dir, ['src/c.ts'], 'frontend-agent', 'task-2', 'dev-lead');
+      const summary = getLockSummary(dir);
+      expect(summary.totalLocked).toBe(3);
+      expect(summary.byAgent['backend-agent']).toBe(2);
+      expect(summary.byAgent['frontend-agent']).toBe(1);
+    });
+
+    it('returns zero for empty project', () => {
+      const dir = createTempDir();
+      const summary = getLockSummary(dir);
+      expect(summary.totalLocked).toBe(0);
+    });
+  });
+});

--- a/packages/core/src/__tests__/scaffold.test.ts
+++ b/packages/core/src/__tests__/scaffold.test.ts
@@ -40,7 +40,7 @@ describe('generateScaffold', () => {
     expect(result.agentCount).toBe(19);
     expect(result.skillCount).toBe(13);
     expect(result.commandCount).toBe(8);
-    expect(result.hookCount).toBe(16);
+    expect(result.hookCount).toBe(17);
     expect(result.filesCreated).toBeGreaterThan(0);
   });
 

--- a/packages/core/src/generators/file-lock-manager.ts
+++ b/packages/core/src/generators/file-lock-manager.ts
@@ -1,0 +1,186 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+
+export interface FileLock {
+  file: string;
+  agent: string;
+  task: string;
+  coordinator: string;
+  lockedAt: string;
+}
+
+export interface LockConflict {
+  file: string;
+  requestingAgent: string;
+  requestingTask: string;
+  lockedBy: string;
+  lockedTask: string;
+  lockedAt: string;
+}
+
+export interface LockResult {
+  success: boolean;
+  locked: string[];
+  conflicts: LockConflict[];
+}
+
+function lockFilePath(projectDir: string): string {
+  return join(projectDir, '.fishi', 'state', 'file-locks.yaml');
+}
+
+/**
+ * Read all current file locks.
+ */
+export function readFileLocks(projectDir: string): FileLock[] {
+  const p = lockFilePath(projectDir);
+  if (!existsSync(p)) return [];
+  const content = readFileSync(p, 'utf-8');
+
+  // Simple YAML parsing for our known structure
+  const locks: FileLock[] = [];
+  const lockBlocks = content.split(/\n\s*-\s+file:\s*/).slice(1);
+
+  for (const block of lockBlocks) {
+    const lines = ('file: ' + block).split('\n');
+    const lock: Partial<FileLock> = {};
+    for (const line of lines) {
+      const fileMatch = line.match(/^\s*file:\s*['"]?(.+?)['"]?\s*$/);
+      const agentMatch = line.match(/^\s*agent:\s*['"]?(.+?)['"]?\s*$/);
+      const taskMatch = line.match(/^\s*task:\s*['"]?(.+?)['"]?\s*$/);
+      const coordMatch = line.match(/^\s*coordinator:\s*['"]?(.+?)['"]?\s*$/);
+      const timeMatch = line.match(/^\s*locked_at:\s*['"]?(.+?)['"]?\s*$/);
+      if (fileMatch) lock.file = fileMatch[1];
+      if (agentMatch) lock.agent = agentMatch[1];
+      if (taskMatch) lock.task = taskMatch[1];
+      if (coordMatch) lock.coordinator = coordMatch[1];
+      if (timeMatch) lock.lockedAt = timeMatch[1];
+    }
+    if (lock.file && lock.agent) {
+      locks.push(lock as FileLock);
+    }
+  }
+
+  return locks;
+}
+
+/**
+ * Write file locks to disk.
+ */
+function writeLocks(projectDir: string, locks: FileLock[]): void {
+  const dir = dirname(lockFilePath(projectDir));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  if (locks.length === 0) {
+    writeFileSync(lockFilePath(projectDir), 'locks: []\n', 'utf-8');
+    return;
+  }
+
+  let yaml = 'locks:\n';
+  for (const lock of locks) {
+    yaml += `  - file: "${lock.file}"\n`;
+    yaml += `    agent: "${lock.agent}"\n`;
+    yaml += `    task: "${lock.task}"\n`;
+    yaml += `    coordinator: "${lock.coordinator}"\n`;
+    yaml += `    locked_at: "${lock.lockedAt}"\n`;
+  }
+  writeFileSync(lockFilePath(projectDir), yaml, 'utf-8');
+}
+
+/**
+ * Check if files can be locked (no conflicts with existing locks).
+ */
+export function checkLockConflicts(
+  projectDir: string,
+  files: string[],
+  agent: string,
+  task: string
+): LockConflict[] {
+  const existing = readFileLocks(projectDir);
+  const conflicts: LockConflict[] = [];
+
+  for (const file of files) {
+    const locked = existing.find(l => l.file === file && l.agent !== agent);
+    if (locked) {
+      conflicts.push({
+        file,
+        requestingAgent: agent,
+        requestingTask: task,
+        lockedBy: locked.agent,
+        lockedTask: locked.task,
+        lockedAt: locked.lockedAt,
+      });
+    }
+  }
+
+  return conflicts;
+}
+
+/**
+ * Acquire locks on files for an agent's task.
+ * Returns success=true if all locks acquired, or conflicts if any file is already locked.
+ */
+export function acquireLocks(
+  projectDir: string,
+  files: string[],
+  agent: string,
+  task: string,
+  coordinator: string
+): LockResult {
+  const conflicts = checkLockConflicts(projectDir, files, agent, task);
+
+  if (conflicts.length > 0) {
+    return { success: false, locked: [], conflicts };
+  }
+
+  const existing = readFileLocks(projectDir);
+  const now = new Date().toISOString();
+  const newLocks: FileLock[] = [];
+
+  for (const file of files) {
+    // Skip if already locked by same agent
+    if (existing.some(l => l.file === file && l.agent === agent)) continue;
+    newLocks.push({ file, agent, task, coordinator, lockedAt: now });
+  }
+
+  writeLocks(projectDir, [...existing, ...newLocks]);
+  return { success: true, locked: files, conflicts: [] };
+}
+
+/**
+ * Release all locks held by an agent (after task completion/merge/cleanup).
+ */
+export function releaseLocks(projectDir: string, agent: string, task?: string): string[] {
+  const existing = readFileLocks(projectDir);
+  const released: string[] = [];
+  const remaining: FileLock[] = [];
+
+  for (const lock of existing) {
+    if (lock.agent === agent && (!task || lock.task === task)) {
+      released.push(lock.file);
+    } else {
+      remaining.push(lock);
+    }
+  }
+
+  writeLocks(projectDir, remaining);
+  return released;
+}
+
+/**
+ * Get all locks for a specific agent.
+ */
+export function getAgentLocks(projectDir: string, agent: string): FileLock[] {
+  return readFileLocks(projectDir).filter(l => l.agent === agent);
+}
+
+/**
+ * Get lock status summary — how many files locked, by which agents.
+ */
+export function getLockSummary(projectDir: string): { totalLocked: number; byAgent: Record<string, number> } {
+  const locks = readFileLocks(projectDir);
+  const byAgent: Record<string, number> = {};
+  for (const lock of locks) {
+    byAgent[lock.agent] = (byAgent[lock.agent] || 0) + 1;
+  }
+  return { totalLocked: locks.length, byAgent };
+}

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -21,3 +21,5 @@ export { runSecurityScan, generateSecurityReport, getScanRules } from './securit
 export type { SecurityFinding, SecurityReport, Severity } from './security-scanner';
 export { getPatternCategories, getPatternsByCategory, getPattern, searchPatterns, saveSelectedPatterns, readSelectedPatterns, generatePatternGuide } from './pattern-marketplace';
 export type { Pattern, PatternCategory, SelectedPatterns } from './pattern-marketplace';
+export { readFileLocks, checkLockConflicts, acquireLocks, releaseLocks, getAgentLocks, getLockSummary } from './file-lock-manager';
+export type { FileLock, LockConflict, LockResult } from './file-lock-manager';

--- a/packages/core/src/generators/scaffold.ts
+++ b/packages/core/src/generators/scaffold.ts
@@ -71,6 +71,7 @@ import { getMemoryManagerScript } from '../templates/hooks/memory-manager.js';
 import { getLearningsManagerScript } from '../templates/hooks/learnings-manager.js';
 import { getDocCheckerScript } from '../templates/hooks/doc-checker.js';
 import { getMonitorEmitterScript } from '../templates/hooks/monitor-emitter.js';
+import { getFileLockHookScript } from '../templates/hooks/file-lock-hook.js';
 
 // Command templates
 import { getInitCommand } from '../templates/commands/init-command.js';
@@ -274,7 +275,8 @@ export async function generateScaffold(
   await write('.fishi/scripts/learnings-manager.mjs', getLearningsManagerScript());
   await write('.fishi/scripts/doc-checker.mjs', getDocCheckerScript());
   await write('.fishi/scripts/monitor-emitter.mjs', getMonitorEmitterScript());
-  const hookCount = 16;
+  await write('.fishi/scripts/file-lock-hook.mjs', getFileLockHookScript());
+  const hookCount = 17;
 
   // ── Initial TODO Files ─────────────────────────────────────────────
   const todoTemplate = (name: string) => `# TODO — ${name}\n\n## Active\n\n## Completed\n`;
@@ -369,6 +371,7 @@ export async function generateScaffold(
     projectType: options.projectType,
   }));
   await write('.fishi/state/agent-registry.yaml', getAgentRegistryTemplate());
+  await write('.fishi/state/file-locks.yaml', 'locks: []\n');
   await write('.fishi/state/task-graph.yaml', 'tasks: []\ndependencies: []\n');
   await write('.fishi/state/gates.yaml', 'gates: []\n');
   await write('.fishi/state/monitor.json', JSON.stringify({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,7 @@ export {
   getLearningsManagerScript,
   getDocCheckerScript,
   getMonitorEmitterScript,
+  getFileLockHookScript,
 } from './templates/hooks/index';
 
 // Command templates
@@ -167,3 +168,5 @@ export { runSecurityScan, generateSecurityReport, getScanRules } from './generat
 export type { SecurityFinding, SecurityReport, Severity as SecuritySeverity } from './generators/index';
 export { getPatternCategories, getPatternsByCategory, getPattern, searchPatterns, saveSelectedPatterns, readSelectedPatterns, generatePatternGuide } from './generators/index';
 export type { Pattern, PatternCategory, SelectedPatterns } from './generators/index';
+export { readFileLocks, checkLockConflicts, acquireLocks, releaseLocks, getAgentLocks, getLockSummary } from './generators/index';
+export type { FileLock, LockConflict, LockResult } from './generators/index';

--- a/packages/core/src/templates/hooks/file-lock-hook.ts
+++ b/packages/core/src/templates/hooks/file-lock-hook.ts
@@ -1,0 +1,141 @@
+export function getFileLockHookScript(): string {
+  return `#!/usr/bin/env node
+// file-lock-hook.mjs — FISHI File Lock Manager
+// Prevents worktree conflicts by locking files before agent assignment.
+// Usage:
+//   node .fishi/scripts/file-lock-hook.mjs check --files "src/a.ts,src/b.ts" --agent backend-agent --task auth
+//   node .fishi/scripts/file-lock-hook.mjs lock --files "src/a.ts" --agent backend-agent --task auth --coordinator dev-lead
+//   node .fishi/scripts/file-lock-hook.mjs release --agent backend-agent [--task auth]
+//   node .fishi/scripts/file-lock-hook.mjs status
+//   node .fishi/scripts/file-lock-hook.mjs agent-locks --agent backend-agent
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+
+const ROOT = process.env.FISHI_PROJECT_ROOT || process.cwd();
+const LOCK_FILE = join(ROOT, '.fishi', 'state', 'file-locks.yaml');
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\\n');
+}
+
+function fail(msg) {
+  out({ error: msg });
+  process.exit(1);
+}
+
+function readLocks() {
+  if (!existsSync(LOCK_FILE)) return [];
+  const content = readFileSync(LOCK_FILE, 'utf-8');
+  const locks = [];
+  const blocks = content.split(/\\n\\s*-\\s+file:\\s*/).slice(1);
+  for (const block of blocks) {
+    const lines = ('file: ' + block).split('\\n');
+    const lock = {};
+    for (const line of lines) {
+      const fm = line.match(/^\\s*file:\\s*["']?(.+?)["']?\\s*$/);
+      const am = line.match(/^\\s*agent:\\s*["']?(.+?)["']?\\s*$/);
+      const tm = line.match(/^\\s*task:\\s*["']?(.+?)["']?\\s*$/);
+      const cm = line.match(/^\\s*coordinator:\\s*["']?(.+?)["']?\\s*$/);
+      const lm = line.match(/^\\s*locked_at:\\s*["']?(.+?)["']?\\s*$/);
+      if (fm) lock.file = fm[1];
+      if (am) lock.agent = am[1];
+      if (tm) lock.task = tm[1];
+      if (cm) lock.coordinator = cm[1];
+      if (lm) lock.lockedAt = lm[1];
+    }
+    if (lock.file && lock.agent) locks.push(lock);
+  }
+  return locks;
+}
+
+function writeLocks(locks) {
+  const dir = dirname(LOCK_FILE);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (locks.length === 0) { writeFileSync(LOCK_FILE, 'locks: []\\n', 'utf-8'); return; }
+  let yaml = 'locks:\\n';
+  for (const l of locks) {
+    yaml += '  - file: "' + l.file + '"\\n';
+    yaml += '    agent: "' + l.agent + '"\\n';
+    yaml += '    task: "' + l.task + '"\\n';
+    yaml += '    coordinator: "' + (l.coordinator || '') + '"\\n';
+    yaml += '    locked_at: "' + l.lockedAt + '"\\n';
+  }
+  writeFileSync(LOCK_FILE, yaml, 'utf-8');
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const cmd = args[0];
+  const opts = {};
+  for (let i = 1; i < args.length; i += 2) {
+    const key = args[i]?.replace(/^--/, '');
+    opts[key] = args[i + 1];
+  }
+  return { cmd, opts };
+}
+
+const { cmd, opts } = parseArgs();
+
+if (cmd === 'check') {
+  if (!opts.files || !opts.agent || !opts.task) fail('Usage: check --files "a,b" --agent X --task Y');
+  const files = opts.files.split(',').map(f => f.trim());
+  const locks = readLocks();
+  const conflicts = [];
+  for (const file of files) {
+    const locked = locks.find(l => l.file === file && l.agent !== opts.agent);
+    if (locked) conflicts.push({ file, lockedBy: locked.agent, lockedTask: locked.task, lockedAt: locked.lockedAt });
+  }
+  out({ conflicts, hasConflicts: conflicts.length > 0 });
+
+} else if (cmd === 'lock') {
+  if (!opts.files || !opts.agent || !opts.task) fail('Usage: lock --files "a,b" --agent X --task Y --coordinator Z');
+  const files = opts.files.split(',').map(f => f.trim());
+  const locks = readLocks();
+  // Check conflicts first
+  const conflicts = [];
+  for (const f of files) {
+    const locked = locks.find(l => l.file === f && l.agent !== opts.agent);
+    if (locked) conflicts.push({ file: f, lockedBy: locked.agent, lockedTask: locked.task });
+  }
+  if (conflicts.length > 0) {
+    out({ success: false, conflicts });
+    process.exit(1);
+  }
+  const now = new Date().toISOString();
+  for (const f of files) {
+    if (!locks.some(l => l.file === f && l.agent === opts.agent)) {
+      locks.push({ file: f, agent: opts.agent, task: opts.task, coordinator: opts.coordinator || '', lockedAt: now });
+    }
+  }
+  writeLocks(locks);
+  out({ success: true, locked: files, agent: opts.agent, task: opts.task });
+
+} else if (cmd === 'release') {
+  if (!opts.agent) fail('Usage: release --agent X [--task Y]');
+  const locks = readLocks();
+  const released = [];
+  const remaining = [];
+  for (const l of locks) {
+    if (l.agent === opts.agent && (!opts.task || l.task === opts.task)) released.push(l.file);
+    else remaining.push(l);
+  }
+  writeLocks(remaining);
+  out({ released, agent: opts.agent, remaining: remaining.length });
+
+} else if (cmd === 'status') {
+  const locks = readLocks();
+  const byAgent = {};
+  for (const l of locks) byAgent[l.agent] = (byAgent[l.agent] || 0) + 1;
+  out({ totalLocked: locks.length, byAgent, locks });
+
+} else if (cmd === 'agent-locks') {
+  if (!opts.agent) fail('Usage: agent-locks --agent X');
+  const locks = readLocks().filter(l => l.agent === opts.agent);
+  out({ agent: opts.agent, lockCount: locks.length, locks });
+
+} else {
+  fail('Unknown command: ' + cmd + '. Use: check, lock, release, status, agent-locks');
+}
+`;
+}

--- a/packages/core/src/templates/hooks/index.ts
+++ b/packages/core/src/templates/hooks/index.ts
@@ -14,3 +14,4 @@ export { getMemoryManagerScript } from './memory-manager';
 export { getLearningsManagerScript } from './learnings-manager';
 export { getDocCheckerScript } from './doc-checker';
 export { getMonitorEmitterScript } from './monitor-emitter';
+export { getFileLockHookScript } from './file-lock-hook';


### PR DESCRIPTION
## Summary

Proactive conflict prevention for parallel agent worktrees. Coordinators lock files before assigning tasks, preventing merge conflicts before they happen.

### How It Works

```
Coordinator assigns task to backend-agent:
  1. Check: are target files locked by another agent?
  2. If locked → conflict detected → reassign or queue
  3. If free → acquire locks → agent starts work
  4. Agent completes → merge → release locks
```

### File Lock Registry (`.fishi/state/file-locks.yaml`)

```yaml
locks:
  - file: "src/auth/login.ts"
    agent: "backend-agent"
    task: "auth-feature"
    coordinator: "dev-lead"
    locked_at: "2026-03-21T..."
```

### Core Functions

| Function | What it does |
|----------|-------------|
| `acquireLocks(dir, files, agent, task, coordinator)` | Lock files — fails if any file already locked by another agent |
| `checkLockConflicts(dir, files, agent, task)` | Check for conflicts without acquiring |
| `releaseLocks(dir, agent, task?)` | Release all locks for an agent (or specific task) |
| `getAgentLocks(dir, agent)` | Get all locks held by an agent |
| `getLockSummary(dir)` | Summary: total locked, count by agent |

### Generated Hook Script

`file-lock-hook.mjs` — CLI for lock operations within the pipeline:
```bash
node .fishi/scripts/file-lock-hook.mjs check --files "src/a.ts,src/b.ts" --agent backend-agent --task auth
node .fishi/scripts/file-lock-hook.mjs lock --files "src/a.ts" --agent backend-agent --task auth --coordinator dev-lead
node .fishi/scripts/file-lock-hook.mjs release --agent backend-agent
node .fishi/scripts/file-lock-hook.mjs status
node .fishi/scripts/file-lock-hook.mjs agent-locks --agent backend-agent
```

### Safety Features
- Same agent can re-lock same file (idempotent)
- Partial conflict detection (some files locked, some free → entire request fails)
- Release by agent or by specific task
- Other agents' locks untouched during release
- Empty locks file initialized during scaffold

### Stats
- 609 tests (594 + 15 new), all passing
- Zero npm dependencies
- Both packages build

## Test plan
- [x] All 609 tests pass
- [x] Acquire locks on free files
- [x] Detect conflicts with other agents
- [x] Allow same agent re-lock (idempotent)
- [x] Partial conflict detection
- [x] Release by agent, release by task
- [x] Multiple agents locking different files
- [x] Lock summary with per-agent counts
- [x] Both packages build
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)